### PR TITLE
Add basic .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+# OS-specific files
+.DS_Store
+Thumbs.db
+Desktop.ini


### PR DESCRIPTION
## Summary
- add a `.gitignore` file that ignores Python bytecode and common OS-specific files

## Testing
- `python3 -m py_compile viga2.0.py`


------
https://chatgpt.com/codex/tasks/task_e_6849aa96b288832b94e78f4493af5479