### PR TITLE
Fix capture area

### DIFF
--- a/viga2.0.py
+++ b/viga2.0.py
@@ -605,7 +605,10 @@ class DesignWindow(QMainWindow):
         self.canvas_dist.draw()
 
     def _capture_design(self):
-        pix = self.centralWidget().grab()
+        rect = self.centralWidget().rect()
+        bottom = self.btn_capture.geometry().top()
+        rect.setHeight(bottom)
+        pix = self.centralWidget().grab(rect)
         QGuiApplication.clipboard().setPixmap(pix)
         QMessageBox.information(
             self,


### PR DESCRIPTION
## Summary
- exclude the bottom button row when capturing the design view

## Testing
- `python -m py_compile viga2.0.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849afd0ab3c832bae971221db74f055