### PR TITLE
Add length input in design stage and basic section views

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 numpy
 scipy
 mplcursors
+pyqtgraph

--- a/src/section2d_view.py
+++ b/src/section2d_view.py
@@ -1,11 +1,70 @@
-"""Interactive 2D view of the beam section."""
+"""Interactive 2D view of the beam section using pyqtgraph."""
 
-from PyQt5.QtWidgets import QWidget
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import QVBoxLayout, QWidget
+import pyqtgraph as pg
 
 
 class Section2DView(QWidget):
-    """Allows dragging and swapping of reinforcement bars."""
+    """Simple 2D representation of the beam section with draggable bars."""
+
+    barraSeleccionada = pyqtSignal(int)
+    barraMovida = pyqtSignal(int, float)
+    longitudCambiada = pyqtSignal(int, float)
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.plot = pg.PlotWidget()
+        layout.addWidget(self.plot)
+        self.plot.setAspectLocked(True)
+        self.plot.hideAxis('left')
+        self.plot.hideAxis('bottom')
+        self._bars = []
+        self._selected = None
+        self.b = 30
+        self.h = 50
+        self.cover = 4
 
+    def set_section(self, b, h, cover):
+        """Configure dimensions of the drawn section."""
+        self.b = b
+        self.h = h
+        self.cover = cover
+        self._draw_section()
+
+    def set_bars(self, diams):
+        """Create draggable bars for each diameter entry."""
+        self._bars = []
+        self.plot.clear()
+        self._draw_section()
+        if not diams:
+            return
+        spacing = (self.b - 2 * self.cover) / max(len(diams) - 1, 1)
+        xs = [self.cover + i * spacing for i in range(len(diams))]
+        for idx, (x, d) in enumerate(zip(xs, diams)):
+            item = pg.ScatterPlotItem([x], [self.cover], size=8 + d * 3,
+                                       brush=pg.mkBrush('b'))
+            item.opts['data'] = idx
+            item.sigClicked.connect(self._on_clicked)
+            self.plot.addItem(item)
+            self._bars.append(item)
+
+    # internal helpers -------------------------------------------------
+    def _draw_section(self):
+        self.plot.clear()
+        rect = pg.QtGui.QGraphicsRectItem(0, 0, self.b, self.h)
+        rect.setPen(pg.mkPen('k'))
+        self.plot.addItem(rect)
+        inner = pg.QtGui.QGraphicsRectItem(
+            self.cover, self.cover,
+            self.b - 2 * self.cover, self.h - 2 * self.cover)
+        inner.setPen(pg.mkPen('r', style=Qt.DashLine))
+        self.plot.addItem(inner)
+
+    def _on_clicked(self, plot, points):
+        if not points:
+            return
+        idx = points[0].data()
+        self._selected = idx
+        self.barraSeleccionada.emit(idx)

--- a/src/section3d_view.py
+++ b/src/section3d_view.py
@@ -1,6 +1,8 @@
-"""3D window rendering the beam model."""
+"""3D window rendering the beam model using pyqtgraph.opengl."""
 
-from PyQt5.QtWidgets import QMainWindow
+from PyQt5.QtWidgets import QMainWindow, QVBoxLayout, QWidget
+import pyqtgraph.opengl as gl
+import numpy as np
 
 
 class Section3DView(QMainWindow):
@@ -8,4 +10,29 @@ class Section3DView(QMainWindow):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.setWindowTitle("Vista 3D")
+        central = QWidget()
+        self.setCentralWidget(central)
+        layout = QVBoxLayout(central)
+        self.view = gl.GLViewWidget()
+        layout.addWidget(self.view)
+        self.view.opts['distance'] = 200
 
+    def set_model(self, b, h, L):
+        """Draw a simple rectangular prism as the beam."""
+        self.view.clear()
+        verts = np.array([
+            [0, 0, 0], [b, 0, 0], [b, h, 0], [0, h, 0],
+            [0, 0, L], [b, 0, L], [b, h, L], [0, h, L]
+        ])
+        faces = np.array([
+            [0, 1, 2], [0, 2, 3],
+            [4, 5, 6], [4, 6, 7],
+            [0, 1, 5], [0, 5, 4],
+            [1, 2, 6], [1, 6, 5],
+            [2, 3, 7], [2, 7, 6],
+            [3, 0, 4], [3, 4, 7]
+        ])
+        mesh = gl.GLMeshItem(vertexes=verts, faces=faces, smooth=False,
+                              color=(0.5, 0.5, 0.5, 0.3), shader='shaded', drawEdges=True)
+        self.view.addItem(mesh)


### PR DESCRIPTION
## Summary
- remove length entry from moments window and fix constant L
- request beam length in the design window
- adjust rebar table headers to `cant.`, `ø''`, `n° capas` and `capas`
- basic `Section2DView` and `Section3DView` widgets using `pyqtgraph`
- include `pyqtgraph` in dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'main.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a5d3dcf10832b8fe576b10b149fee