### PR TITLE
Fix Qt window closing immediately

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,8 @@ def main():
     logging.basicConfig(level=logging.ERROR)
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
-    MomentApp()
+    # Keep a reference to the main window so it isn't garbage collected
+    window = MomentApp()
     sys.exit(app.exec_())
 
 


### PR DESCRIPTION
## Summary
- keep a reference to the `MomentApp` main window so it isn't garbage collected

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ae3d9cc30832bb944bad51fc3785a