### PR TITLE
Implement simple activation check

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ python main.py
 Se abrirá la interfaz gráfica donde se ingresan los momentos y se generan los
 diagramas correspondientes.
 
+## Activación
+
+Al ejecutarse por primera vez, la aplicación solicita una clave de licencia.
+Si la clave coincide con la esperada, se almacena una huella del equipo en
+`key.dat` y los siguientes inicios se validan de forma automática.
+
 
 ## Formulario de datos y flujos
 

--- a/main.py
+++ b/main.py
@@ -2,13 +2,21 @@
 
 import logging
 import sys
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QMessageBox, QInputDialog
 from src.moment_app import MomentApp
+from src.activation import check_activation, activate
 
 
 def main():
     """Start the Qt application."""
     logging.basicConfig(level=logging.ERROR)
+    if not check_activation():
+        key, ok = QInputDialog.getText(
+            None, "Activar VIGAPP 060", "Ingrese la clave:")
+        if not ok or not activate(key):
+            QMessageBox.critical(None, "Licencia", "Clave inv\xE1lida")
+            return
+
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
     # Keep a reference to the main window so it isn't garbage collected

--- a/src/activation.py
+++ b/src/activation.py
@@ -1,0 +1,31 @@
+"""Simple hardware-locked activation handling."""
+
+import hashlib
+import os
+import uuid
+
+# File storing the hardware fingerprint
+KEY_FILE = "key.dat"
+# Static license key distributed to users
+LICENSE_KEY = "ABC123-XYZ"
+
+def hardware_id():
+    """Return a stable identifier for the current machine."""
+    mac = uuid.getnode()
+    return hashlib.sha256(str(mac).encode()).hexdigest()
+
+def activate(key: str) -> bool:
+    """Store the hardware hash if the provided key is correct."""
+    if key != LICENSE_KEY:
+        return False
+    with open(KEY_FILE, "w") as f:
+        f.write(hardware_id())
+    return True
+
+def check_activation() -> bool:
+    """Check that this machine matches the stored activation."""
+    if not os.path.exists(KEY_FILE):
+        return False
+    with open(KEY_FILE) as f:
+        stored = f.read().strip()
+    return stored == hardware_id()


### PR DESCRIPTION
## Summary
- add hardware-locked activation module
- request key on first run in `main.py`
- document activation step in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b3a64e194832ba0ee34487f7404e1