### PR TITLE
Fix QApplication order, tweak captures

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from src.activation import check_activation, activate
 def main():
     """Start the Qt application."""
     logging.basicConfig(level=logging.ERROR)
+    app = QApplication(sys.argv)
     if not check_activation():
         key, ok = QInputDialog.getText(
             None, "Activar VIGAPP 060", "Ingrese la clave:")
@@ -17,7 +18,6 @@ def main():
             QMessageBox.critical(None, "Licencia", "Clave inv\xE1lida")
             return
 
-    app = QApplication(sys.argv)
     app.setStyle("Fusion")
     # Keep a reference to the main window so it isn't garbage collected
     window = MomentApp()

--- a/src/design_window.py
+++ b/src/design_window.py
@@ -496,10 +496,15 @@ class DesignWindow(QMainWindow):
         self.canvas_dist.draw()
 
     def _capture_design(self):
+        widgets = [self.btn_capture, self.btn_memoria, self.btn_view3d, self.btn_salir]
+        for w in widgets:
+            w.hide()
         self.repaint()
         QApplication.processEvents()
-        pix = self.grab()
+        pix = self.centralWidget().grab()
         QGuiApplication.clipboard().setPixmap(pix)
+        for w in widgets:
+            w.show()
         # Sin mensaje emergente
 
     def show_view3d(self):

--- a/src/view3d_window.py
+++ b/src/view3d_window.py
@@ -5,7 +5,10 @@ from PyQt5.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QLabel,
+    QPushButton,
+    QApplication,
 )
+from PyQt5.QtGui import QGuiApplication
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt
 from matplotlib import colors as mcolors
@@ -62,6 +65,9 @@ class View3DWindow(QMainWindow):
         self.ax_sections = [self.fig.add_subplot(1, 3, i + 1) for i in range(3)]
         self.canvas = FigureCanvas(self.fig)
         layout.addWidget(self.canvas)
+        self.btn_capture = QPushButton("Capturar Vista")
+        self.btn_capture.clicked.connect(self._capture_view)
+        layout.addWidget(self.btn_capture)
 
         self.canvas.mpl_connect("pick_event", self._on_pick)
         self.canvas.mpl_connect("key_press_event", self._on_key)
@@ -371,4 +377,11 @@ class View3DWindow(QMainWindow):
         self.selected = (sign, sec, new_idx)
         self.dragging = False
         self.selected_patch = None
+
+    def _capture_view(self):
+        """Copy the canvas to the clipboard."""
+        self.canvas.repaint()
+        QApplication.processEvents()
+        pix = self.canvas.grab()
+        QGuiApplication.clipboard().setPixmap(pix)
 


### PR DESCRIPTION
## Summary
- instantiate `QApplication` before prompting for license key
- hide bottom buttons when capturing design window
- add capture button to the 3D view window

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: "Could not load the Qt platform plugin \"xcb\"")*

------
https://chatgpt.com/codex/tasks/task_e_684b476196a4832b870fbbcae44c4188