### PR TITLE
Handle icon scaling and remove image

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ Esta organización modular facilita la comunicación y coordinación dentro del 
 
 Consulta el archivo [DESARROLLO.md](DESARROLLO.md) para pautas sobre configuración del entorno y aportes al código.
 
+### Icono de la aplicación
+
+Los archivos de icono se almacenan en la carpeta `icon/`. Coloca tu imagen PNG en
+ese directorio con el nombre `vigapp060.png` para que la interfaz lo utilice
+automáticamente. La imagen original debe tener un tamaño de `1024x1024` y la
+aplicación la escalará internamente a `256x256` cuando se inicie.
+
 ## Desarrollo de Refuerzo
 
 Se añadió un botón **Desarrollo de Refuerzo** en la ventana de diseño que abre

--- a/icon/README.md
+++ b/icon/README.md
@@ -1,0 +1,2 @@
+Coloca en esta carpeta la imagen `vigapp060.png` que servirá como icono de la aplicación.
+Debe ser una imagen de `1024x1024` píxeles; la aplicación la escala a `256x256` en tiempo de ejecución.

--- a/main.py
+++ b/main.py
@@ -1,8 +1,11 @@
 """Entry point launching the beam design application."""
 
 import logging
+import os
 import sys
 from PyQt5.QtWidgets import QApplication, QMessageBox, QInputDialog
+from PyQt5.QtGui import QIcon, QPixmap
+from PyQt5.QtCore import Qt
 from src.moment_app import MomentApp
 from src.activation import check_activation, activate
 
@@ -11,6 +14,12 @@ def main():
     """Start the Qt application."""
     logging.basicConfig(level=logging.ERROR)
     app = QApplication(sys.argv)
+    icon_path = os.path.join(
+        os.path.dirname(__file__), "icon", "vigapp060.png")
+    if os.path.exists(icon_path):
+        pix = QPixmap(icon_path).scaled(
+            256, 256, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        app.setWindowIcon(QIcon(pix))
     if not check_activation():
         key, ok = QInputDialog.getText(
             None, "Activar VIGAPP 060", "Ingrese la clave:")


### PR DESCRIPTION
## Summary
- remove `icon/vigapp060.png` so users can supply their own icon
- scale the icon at runtime in `main.py`
- document icon requirements and scaling in README files

## Testing
- `pytest -q`
- `flake8 main.py | head` (shows only pre-existing warnings)


------
https://chatgpt.com/codex/tasks/task_e_684b4faded84832b955c117a3f277d00