### PR TITLE
Implement license counter and appdata path

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ diagramas correspondientes.
 
 Al ejecutarse por primera vez, la aplicación solicita una clave de licencia.
 Si la clave coincide con la esperada, se almacena una huella del equipo en
-`key.dat` y los siguientes inicios se validan de forma automática.
+`key.dat` dentro de la carpeta de datos de la aplicación (por ejemplo
+`%APPDATA%/vigapp060` en Windows) y los siguientes inicios se validan de
+forma automática.
 
 
 ## Formulario de datos y flujos

--- a/main.py
+++ b/main.py
@@ -27,7 +27,15 @@ def main():
         key, ok = QInputDialog.getText(
             None, "Activar VIGAPP 060", "Ingrese la clave:")
         if not ok or not activate(key):
-            QMessageBox.critical(None, "Licencia", "Clave inv\xE1lida")
+            QMessageBox.critical(
+                None,
+                "Licencia",
+                (
+                    "COMUNICARSE AL SIGUIENTE CORREO PARA SOLICTAR LA CLAVE DE "
+                    "ACTIVACION: abelcorderotineo99@gmail.com  cel y wsp : "
+                    "922148420"
+                ),
+            )
             return
 
     app.setStyle("Fusion")

--- a/src/activation.py
+++ b/src/activation.py
@@ -4,22 +4,60 @@ import hashlib
 import os
 import uuid
 
-# File storing the hardware fingerprint
-KEY_FILE = "key.dat"
-# Static license key distributed to users
-LICENSE_KEY = "ABC123-XYZ"
+def _app_dir() -> str:
+    """Return the application data folder."""
+    if os.name == "nt":
+        base = os.getenv("APPDATA", os.path.expanduser("~"))
+    else:
+        base = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
+    path = os.path.join(base, "vigapp060")
+    os.makedirs(path, exist_ok=True)
+    return path
 
-def hardware_id():
+
+APP_DIR = _app_dir()
+# File storing the hardware fingerprint
+KEY_FILE = os.path.join(APP_DIR, "key.dat")
+COUNTER_FILE = os.path.join(APP_DIR, "counter.dat")
+# Static license key prefix
+LICENSE_PREFIX = "ABC"
+LICENSE_SUFFIX = "-XYZ"
+
+
+def _read_counter() -> int:
+    """Return the current license counter."""
+    if os.path.exists(COUNTER_FILE):
+        try:
+            return int(open(COUNTER_FILE).read().strip())
+        except ValueError:
+            pass
+    return 1
+
+
+def _write_counter(val: int) -> None:
+    """Persist the license counter."""
+    with open(COUNTER_FILE, "w") as f:
+        f.write(str(val))
+
+
+def current_license() -> str:
+    """Return the expected license for activation."""
+    counter = _read_counter()
+    return f"{LICENSE_PREFIX}{counter:03d}{LICENSE_SUFFIX}"
+
+def hardware_id() -> str:
     """Return a stable identifier for the current machine."""
     mac = uuid.getnode()
     return hashlib.sha256(str(mac).encode()).hexdigest()
 
+
 def activate(key: str) -> bool:
     """Store the hardware hash if the provided key is correct."""
-    if key != LICENSE_KEY:
+    if key != current_license():
         return False
     with open(KEY_FILE, "w") as f:
         f.write(hardware_id())
+    _write_counter(_read_counter() + 1)
     return True
 
 def check_activation() -> bool:


### PR DESCRIPTION
## Summary
- store activation data under OS application directory
- increment license counter each activation
- update invalid key message to show contact info
- document new key.dat location in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b580f132c832b8857e773253c049d