### PR TITLE
Update activation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ diagramas correspondientes.
 Al ejecutarse por primera vez, la aplicación solicita una clave de licencia.
 Si la clave coincide con la esperada, se almacena una huella del equipo en
 `key.dat` dentro de la carpeta de datos de la aplicación (por ejemplo
-`%APPDATA%/vigapp060` en Windows) y los siguientes inicios se validan de
+`%LOCALAPPDATA%\vigapp060` en Windows) y los siguientes inicios se validan de
 forma automática.
 
 

--- a/src/activation.py
+++ b/src/activation.py
@@ -7,7 +7,10 @@ import uuid
 def _app_dir() -> str:
     """Return the application data folder."""
     if os.name == "nt":
-        base = os.getenv("APPDATA", os.path.expanduser("~"))
+        base = os.getenv(
+            "LOCALAPPDATA",
+            os.path.join(os.path.expanduser("~"), "AppData", "Local"),
+        )
     else:
         base = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
     path = os.path.join(base, "vigapp060")


### PR DESCRIPTION
## Summary
- store activation data under `%LOCALAPPDATA%\vigapp060` on Windows
- clarify location in README

## Testing
- `python -m py_compile src/activation.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684b9a2d78d8832bbd49c2d3667be397