### PR TITLE
Implement encrypted hardware activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,12 @@ diagramas correspondientes.
 ## Activación
 
 Al ejecutarse por primera vez, la aplicación solicita una clave de licencia.
-Si la clave coincide con la esperada, se almacena una huella del equipo en
-`key.dat` dentro de la carpeta de datos de la aplicación (por ejemplo
-`%LOCALAPPDATA%\vigapp060` en Windows) y los siguientes inicios se validan de
-forma automática.
+Si la clave coincide con la esperada, se almacena una huella del equipo en un
+archivo cifrado `key.dat` dentro de la carpeta de datos de la aplicación (por
+ejemplo `%LOCALAPPDATA%\vigapp060` en Windows). Esta huella se genera a partir
+de la MAC, el nombre de host y el número de serie del primer disco disponible.
+En ejecuciones posteriores se descifra dicho archivo y se compara la huella con
+la de la máquina actual para verificar la validez de la licencia.
 
 
 ## Formulario de datos y flujos


### PR DESCRIPTION
## Summary
- encrypt activation key and counter using simple XOR+Base64
- use MAC, hostname and disk serial in hardware fingerprint
- document encrypted activation in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c51837460832baac8a7989bc20ba3