### PR TITLE
Add simple license activation scripts

### DIFF
--- a/simple_activation/generador_licencia.py
+++ b/simple_activation/generador_licencia.py
@@ -1,0 +1,23 @@
+import hashlib
+import sys
+
+SECRET_KEY = "mi_clave_secreta"  # Cambiar por la clave real
+
+
+def generar_clave(serial: str) -> str:
+    """Genera el hash SHA256 de serial+SECRET_KEY."""
+    data = (serial + SECRET_KEY).encode()
+    return hashlib.sha256(data).hexdigest()
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Uso: python generador_licencia.py <serial>")
+        sys.exit(1)
+    serial = sys.argv[1]
+    clave = generar_clave(serial)
+    print(clave)
+
+
+if __name__ == "__main__":
+    main()

--- a/simple_activation/main.py
+++ b/simple_activation/main.py
@@ -1,0 +1,41 @@
+import hashlib
+import subprocess
+
+SECRET_KEY = "mi_clave_secreta"  # Debe coincidir con la usada en generador_licencia.py
+
+
+def obtener_serial() -> str:
+    """Devuelve el serial del primer disco usando wmic (solo en Windows)."""
+    try:
+        salida = subprocess.check_output(
+            ["wmic", "diskdrive", "get", "SerialNumber"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        lineas = [l.strip() for l in salida.splitlines() if l.strip()]
+        return lineas[1] if len(lineas) > 1 else ""
+    except Exception:
+        return ""
+
+
+def calcular_clave(serial: str) -> str:
+    datos = (serial + SECRET_KEY).encode()
+    return hashlib.sha256(datos).hexdigest()
+
+
+def main():
+    serial = obtener_serial()
+    if not serial:
+        print("No se pudo obtener el serial del disco.")
+        return
+    print(f"ID de hardware: {serial}")
+    clave_ingresada = input("Ingrese la clave de activacion: ").strip()
+    clave_correcta = calcular_clave(serial)
+    if clave_ingresada == clave_correcta:
+        print("Programa activado correctamente!")
+    else:
+        print("Clave invalida. Por favor verifique el serial y la clave.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a new folder with example scripts for a simple license mechanism
- `generador_licencia.py` generates a SHA256 key from the disk serial
- `main.py` obtains the disk serial with `wmic` and validates the activation key

## Testing
- `python -m py_compile simple_activation/main.py simple_activation/generador_licencia.py`

------
https://chatgpt.com/codex/tasks/task_e_684c5b167ee0832b8f04da38fe604bcb