### PR TITLE
Add activation dialog and license generator

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,11 +4,12 @@ import logging
 import os
 import sys
 import ctypes
-from PyQt5.QtWidgets import QApplication, QMessageBox, QInputDialog
+from PyQt5.QtWidgets import QApplication, QMessageBox, QDialog
 from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtCore import Qt
 from src.moment_app import MomentApp
 from src.activation import check_activation, activate, machine_code
+from src.activation_dialog import ActivationDialog
 
 
 def main():
@@ -24,19 +25,8 @@ def main():
             256, 256, Qt.KeepAspectRatio, Qt.SmoothTransformation)
         app.setWindowIcon(QIcon(pix))
     if not check_activation():
-        code = machine_code()
-        msg = f"Codigo de esta PC:\n{code}\n\nIngrese la clave:"
-        key, ok = QInputDialog.getText(None, "Activar VIGAPP 060", msg)
-        if not ok or not activate(key):
-            QMessageBox.critical(
-                None,
-                "Licencia",
-                (
-                    "COMUNICARSE AL SIGUIENTE CORREO PARA SOLICTAR LA CLAVE DE "
-                    "ACTIVACION: abelcorderotineo99@gmail.com  cel y wsp : "
-                    "922148420"
-                ),
-            )
+        dlg = ActivationDialog()
+        if dlg.exec_() != QDialog.Accepted:
             return
 
     app.setStyle("Fusion")

--- a/scripts/gui_generate_license.py
+++ b/scripts/gui_generate_license.py
@@ -1,0 +1,68 @@
+import sys
+from PyQt5.QtWidgets import (
+    QApplication,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QSpinBox,
+    QLabel,
+    QMessageBox,
+)
+from src.activation import license_for
+
+
+class LicenseGenerator(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Generador de Licencia")
+        layout = QVBoxLayout(self)
+
+        self.code_edit = QLineEdit()
+        self.code_edit.setPlaceholderText("ID de equipo")
+        layout.addWidget(self.code_edit)
+
+        counter_row = QHBoxLayout()
+        counter_row.addWidget(QLabel("Contador:"))
+        self.counter = QSpinBox()
+        self.counter.setMinimum(1)
+        self.counter.setMaximum(9999)
+        counter_row.addWidget(self.counter)
+        layout.addLayout(counter_row)
+
+        self.license_edit = QLineEdit()
+        self.license_edit.setReadOnly(True)
+        layout.addWidget(self.license_edit)
+
+        btn_row = QHBoxLayout()
+        gen_btn = QPushButton("Generar")
+        copy_btn = QPushButton("Copiar")
+        btn_row.addWidget(gen_btn)
+        btn_row.addWidget(copy_btn)
+        layout.addLayout(btn_row)
+
+        gen_btn.clicked.connect(self.generate)
+        copy_btn.clicked.connect(self.copy)
+
+    def generate(self):
+        code = self.code_edit.text().strip()
+        if not code:
+            QMessageBox.warning(self, "Error", "Ingrese el ID")
+            return
+        lic = license_for(code, self.counter.value())
+        self.license_edit.setText(lic)
+
+    def copy(self):
+        QApplication.clipboard().setText(self.license_edit.text())
+
+
+def main():
+    app = QApplication(sys.argv)
+    win = LicenseGenerator()
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/activation.py
+++ b/src/activation.py
@@ -91,6 +91,18 @@ def _write_counter(val: int) -> None:
         f.write(_encrypt(str(val)))
 
 
+def machine_code() -> str:
+    """Return the user-visible code for this machine."""
+    return hardware_id()[:16]
+
+
+def license_for(code: str, counter: int) -> str:
+    """Return the license string for ``code`` and ``counter``."""
+    raw = f"{code}:{counter}:{_SECRET.decode()}"
+    digest = hashlib.sha256(raw.encode()).hexdigest()[:8].upper()
+    return f"{LICENSE_PREFIX}{digest}{LICENSE_SUFFIX}"
+
+
 def current_license() -> str:
     """Return the expected license for activation."""
     counter = _read_counter()

--- a/src/activation_dialog.py
+++ b/src/activation_dialog.py
@@ -1,0 +1,68 @@
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QMessageBox,
+)
+from PyQt5.QtCore import Qt
+
+from .activation import machine_code, activate
+
+
+class ActivationDialog(QDialog):
+    """Simple dialog requesting the activation key."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Activar VIGAPP 060")
+        self.setModal(True)
+        code = machine_code()
+        msg = (
+            f"ID de equipo: {code}\n\n"
+            "Comparta este codigo al contacto para solicitar su clave de "
+            "activacion. Si ya la tiene, ingrese la clave y presione Activar."
+        )
+        label = QLabel(msg)
+        label.setWordWrap(True)
+
+        self.input = QLineEdit()
+        self.input.setPlaceholderText("Clave de activacion")
+
+        contact_btn = QPushButton("Contacto")
+        activate_btn = QPushButton("Activar")
+        exit_btn = QPushButton("Salir")
+
+        contact_btn.clicked.connect(self._show_contact)
+        activate_btn.clicked.connect(self._on_activate)
+        exit_btn.clicked.connect(self.reject)
+
+        btn_row = QHBoxLayout()
+        btn_row.addWidget(contact_btn)
+        btn_row.addWidget(activate_btn)
+        btn_row.addWidget(exit_btn)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(label)
+        layout.addWidget(self.input)
+        layout.addLayout(btn_row)
+
+    def _show_contact(self):
+        QMessageBox.information(
+            self,
+            "Contacto",
+            (
+                "COMUNICARSE AL SIGUIENTE CORREO PARA SOLICTAR LA CLAVE DE "
+                "ACTIVACION: abelcorderotineo99@gmail.com  cel y wsp : 922148420"
+            ),
+        )
+
+    def _on_activate(self):
+        key = self.input.text().strip()
+        if activate(key):
+            QMessageBox.information(self, "Licencia", "Programa activado correctamente!")
+            self.accept()
+        else:
+            QMessageBox.warning(self, "Licencia", "Clave invalida. Verifique e intente nuevamente.")


### PR DESCRIPTION
## Summary
- add `machine_code` and `license_for` helpers back into `activation.py`
- new `ActivationDialog` with buttons for contact, activate and exit
- update `main.py` to use the dialog
- implement GUI license generator script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c61127710832b95bd3d6176eff85d