### PR TITLE
Fix ruff warnings across modules

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,11 +4,11 @@ import logging
 import os
 import sys
 import ctypes
-from PyQt5.QtWidgets import QApplication, QMessageBox, QDialog
+from PyQt5.QtWidgets import QApplication, QDialog
 from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtCore import Qt
 from src.moment_app import MomentApp
-from src.activation import check_activation, activate, machine_code
+from src.activation import check_activation
 from src.activation_dialog import ActivationDialog
 
 
@@ -31,7 +31,7 @@ def main():
 
     app.setStyle("Fusion")
     # Keep a reference to the main window so it isn't garbage collected
-    window = MomentApp()
+    _window = MomentApp()
     sys.exit(app.exec_())
 
 

--- a/simple_activation/main.py
+++ b/simple_activation/main.py
@@ -12,7 +12,7 @@ def obtener_serial() -> str:
             stderr=subprocess.DEVNULL,
             text=True,
         )
-        lineas = [l.strip() for l in salida.splitlines() if l.strip()]
+        lineas = [line.strip() for line in salida.splitlines() if line.strip()]
         return lineas[1] if len(lineas) > 1 else ""
     except Exception:
         return ""

--- a/src/activation.py
+++ b/src/activation.py
@@ -61,14 +61,14 @@ def _disk_serial() -> str:
                 stderr=subprocess.DEVNULL,
                 text=True,
             )
-            lines = [l.strip() for l in out.splitlines() if l.strip()][1:]
+            lines = [line.strip() for line in out.splitlines() if line.strip()][1:]
             return lines[0] if lines else ""
         out = subprocess.check_output(
             ["lsblk", "-dn", "-o", "serial"],
             stderr=subprocess.DEVNULL,
             text=True,
         )
-        lines = [l.strip() for l in out.splitlines() if l.strip()]
+        lines = [line.strip() for line in out.splitlines() if line.strip()]
         return lines[0] if lines else ""
     except Exception:
         return ""

--- a/src/activation_dialog.py
+++ b/src/activation_dialog.py
@@ -7,7 +7,6 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QMessageBox,
 )
-from PyQt5.QtCore import Qt
 
 from .activation import machine_code, activate
 

--- a/src/design_window.py
+++ b/src/design_window.py
@@ -69,13 +69,9 @@ class DesignWindow(QMainWindow):
     def _required_areas(self):
         try:
             b = float(self.edits["b (cm)"].text())
-            h = float(self.edits["h (cm)"].text())
-            r = float(self.edits["r (cm)"].text())
             fc = float(self.edits["f'c (kg/cm²)"].text())
             fy = float(self.edits["fy (kg/cm²)"].text())
             phi = float(self.edits["φ"].text())
-            de = DIAM_CM.get(self.cb_estribo.currentText(), 0)
-            db = DIAM_CM.get(self.cb_varilla.currentText(), 0)
         except ValueError:
             return np.zeros(3), np.zeros(3)
 
@@ -126,9 +122,9 @@ class DesignWindow(QMainWindow):
                     layer_diams[layer] = DIAM_CM.get(dia_key, 0)
 
         max_layer = 1
-        for l in range(1, 5):
-            if layer_areas[l] > 0:
-                max_layer = max(max_layer, l)
+        for layer_num in range(1, 5):
+            if layer_areas[layer_num] > 0:
+                max_layer = max(max_layer, layer_num)
         self.layer_combo.setCurrentText(str(max_layer))
 
         db1 = layer_diams[1]
@@ -192,18 +188,21 @@ class DesignWindow(QMainWindow):
         # Combos para diámetro de estribo y de varilla
         estribo_opts = ["8mm", "3/8\"", "1/2\""]
         layout.addWidget(QLabel("ϕ estribo"), len(labels), 0)
-        self.cb_estribo = QComboBox(); self.cb_estribo.addItems(estribo_opts)
+        self.cb_estribo = QComboBox()
+        self.cb_estribo.addItems(estribo_opts)
         self.cb_estribo.setCurrentText('3/8"')
         layout.addWidget(self.cb_estribo, len(labels), 1)
 
         varilla_opts = ["1/2\"", "5/8\"", "3/4\"", "1\""]
         layout.addWidget(QLabel("ϕ varilla"), len(labels)+1, 0)
-        self.cb_varilla = QComboBox(); self.cb_varilla.addItems(varilla_opts)
+        self.cb_varilla = QComboBox()
+        self.cb_varilla.addItems(varilla_opts)
         self.cb_varilla.setCurrentText('5/8"')
         layout.addWidget(self.cb_varilla, len(labels)+1, 1)
 
         layout.addWidget(QLabel("N\u00b0 capas"), len(labels)+2, 0)
-        self.layer_combo = QComboBox(); self.layer_combo.addItems(["1", "2", "3", "4"])
+        self.layer_combo = QComboBox()
+        self.layer_combo.addItems(["1", "2", "3", "4"])
         layout.addWidget(self.layer_combo, len(labels)+2, 1)
 
         pos_labels = ["M1-", "M2-", "M3-", "M1+", "M2+", "M3+"]
@@ -313,11 +312,19 @@ class DesignWindow(QMainWindow):
         qty_opts = [""] + [str(i) for i in range(1, 11)]
         dia_opts = ["", "1/2\"", "5/8\"", "3/4\"", "1\""]
         row_layout = QHBoxLayout()
-        q = QComboBox(); q.addItems(qty_opts); q.setCurrentText("2")
-        d = QComboBox(); d.addItems(dia_opts); d.setCurrentText('1/2"')
-        c = QComboBox(); c.addItems(["1", "2", "3", "4"]); c.setCurrentText("1")
-        btn_add = QPushButton("+"); btn_add.setFixedWidth(20)
-        btn_rem = QPushButton("-"); btn_rem.setFixedWidth(20)
+        q = QComboBox()
+        q.addItems(qty_opts)
+        q.setCurrentText("2")
+        d = QComboBox()
+        d.addItems(dia_opts)
+        d.setCurrentText('1/2"')
+        c = QComboBox()
+        c.addItems(["1", "2", "3", "4"])
+        c.setCurrentText("1")
+        btn_add = QPushButton("+")
+        btn_add.setFixedWidth(20)
+        btn_rem = QPushButton("-")
+        btn_rem.setFixedWidth(20)
         row_layout.addWidget(q)
         row_layout.addWidget(d)
         row_layout.addWidget(c)
@@ -345,8 +352,6 @@ class DesignWindow(QMainWindow):
             b = float(self.edits["b (cm)"].text())
             h = float(self.edits["h (cm)"].text())
             r = float(self.edits["r (cm)"].text())
-            de = DIAM_CM.get(self.cb_estribo.currentText(), 0)
-            db = DIAM_CM.get(self.cb_varilla.currentText(), 0)
         except ValueError:
             return
 

--- a/src/moment_app.py
+++ b/src/moment_app.py
@@ -1,4 +1,3 @@
-import sys
 import logging
 from PyQt5.QtWidgets import (
     QApplication, QMainWindow, QWidget, QGridLayout, QLabel,

--- a/src/section2d_view.py
+++ b/src/section2d_view.py
@@ -87,7 +87,6 @@ class Section2DView(QWidget):
             self.longitudCambiada.emit(idx, value)
 
     def _on_drag_finished(self, roi):
-        idx = roi.bar_index
         center_x = roi.pos()[0] + roi.size()[0] / 2
         self._bars.sort(key=lambda r: r.pos()[0])
         for i, r in enumerate(self._bars):

--- a/src/view3d_window.py
+++ b/src/view3d_window.py
@@ -4,7 +4,6 @@ from PyQt5.QtWidgets import (
     QMainWindow,
     QWidget,
     QVBoxLayout,
-    QLabel,
     QPushButton,
     QApplication,
     QLineEdit,
@@ -12,7 +11,6 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtGui import QGuiApplication
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt
-from matplotlib import colors as mcolors
 from matplotlib import patches
 import numpy as np
 
@@ -288,8 +286,8 @@ class View3DWindow(QMainWindow):
         orders_pos = self.pos_orders[idx] if idx < len(self.pos_orders) else []
         orders_neg = self.neg_orders[idx] if idx < len(self.neg_orders) else []
 
-        pos_counts = [len(pos_layers.get(l, [])) for l in sorted(pos_layers)]
-        neg_counts = [len(neg_layers.get(l, [])) for l in sorted(neg_layers)]
+        pos_counts = [len(pos_layers.get(layer, [])) for layer in sorted(pos_layers)]
+        neg_counts = [len(neg_layers.get(layer, [])) for layer in sorted(neg_layers)]
 
         pos_y = self._layer_positions_bottom(pos_layers, r, de)
         neg_y = self._layer_positions_top(neg_layers, r, de, h)


### PR DESCRIPTION
## Summary
- remove unused imports and variables
- rename ambiguous loop variables
- split multi-statement lines in `DesignWindow`
- keep the main window reference with an underscore
- run ruff linting cleanly

## Testing
- `ruff check`

------
https://chatgpt.com/codex/tasks/task_e_684c6024f198832b908dc5234862e13d