### PR TITLE
Adjust font sizes for formulas

### DIFF
--- a/src/design_window.py
+++ b/src/design_window.py
@@ -619,7 +619,12 @@ class DesignWindow(QMainWindow):
 
         html = (
             "<html><head>"
-            "<style>p{margin:6px 0;} .eq{margin-left:20px;}</style>"
+            "<style>"
+            "body{font-size:11pt;font-family:'Times New Roman';}"
+            "h2{font-size:12pt;margin:8px 0;}"
+            "h3{font-size:11pt;margin:6px 0;}"
+            "p{margin:6px 0;} .eq{margin-left:20px;}"
+            "</style>"
             "</head><body>"
             + "\n".join(lines) +
             "</body></html>"

--- a/src/formula_window.py
+++ b/src/formula_window.py
@@ -75,7 +75,7 @@ class FormulaWindow(QMainWindow):
         latex = sp.latex(eq)
         self.ax.clear()
         self.ax.axis("off")
-        self.ax.text(0.5, 0.5, f"${latex}$", ha="center", va="center", fontsize=20)
+        self.ax.text(0.5, 0.5, f"${latex}$", ha="center", va="center", fontsize=12)
         self.canvas.draw()
 
     # ------------------------------------------------------------------

--- a/src/utils.py
+++ b/src/utils.py
@@ -11,7 +11,7 @@ def color_for_diameter(diam):
     return "#000000"
 
 
-def latex_image(latex: str, fontsize: int = 12) -> str:
+def latex_image(latex: str, fontsize: int = 11) -> str:
     """Return an HTML ``<img>`` tag with a LaTeX expression rendered to PNG."""
     fig = Figure(figsize=(0.01, 0.01))
     ax = fig.add_subplot(111)


### PR DESCRIPTION
## Summary
- style calculation memory with consistent font sizes
- render LaTeX images using 11pt font by default
- shrink formula preview fonts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c66f40940832bae235e13189154be