### PR TITLE
Add robust license generation and counter handling

### DIFF
--- a/scripts/generate_license.py
+++ b/scripts/generate_license.py
@@ -1,4 +1,10 @@
 import argparse
+import os
+import sys
+
+# Ensure the "src" package can be imported when running this script directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from src.activation import license_for
 
 parser = argparse.ArgumentParser(description="Generate VigApp activation code")

--- a/scripts/gui_generate_license.py
+++ b/scripts/gui_generate_license.py
@@ -1,4 +1,6 @@
 import sys
+import os
+
 from PyQt5.QtWidgets import (
     QApplication,
     QWidget,
@@ -10,6 +12,10 @@ from PyQt5.QtWidgets import (
     QLabel,
     QMessageBox,
 )
+
+# Ensure the "src" package is importable when executing this script directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from src.activation import license_for
 
 

--- a/src/activation_dialog.py
+++ b/src/activation_dialog.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QMessageBox,
 )
+from PyQt5.QtGui import QGuiApplication
 
 from .activation import machine_code, activate
 
@@ -18,9 +19,9 @@ class ActivationDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("Activar VIGAPP 060")
         self.setModal(True)
-        code = machine_code()
+        self._code = machine_code()
         msg = (
-            f"ID de equipo: {code}\n\n"
+            f"ID de equipo: {self._code}\n\n"
             "Comparta este codigo al contacto para solicitar su clave de "
             "activacion. Si ya la tiene, ingrese la clave y presione Activar."
         )
@@ -31,15 +32,18 @@ class ActivationDialog(QDialog):
         self.input.setPlaceholderText("Clave de activacion")
 
         contact_btn = QPushButton("Contacto")
+        copy_btn = QPushButton("Copiar ID")
         activate_btn = QPushButton("Activar")
         exit_btn = QPushButton("Salir")
 
         contact_btn.clicked.connect(self._show_contact)
+        copy_btn.clicked.connect(self._copy_id)
         activate_btn.clicked.connect(self._on_activate)
         exit_btn.clicked.connect(self.reject)
 
         btn_row = QHBoxLayout()
         btn_row.addWidget(contact_btn)
+        btn_row.addWidget(copy_btn)
         btn_row.addWidget(activate_btn)
         btn_row.addWidget(exit_btn)
 
@@ -65,3 +69,8 @@ class ActivationDialog(QDialog):
             self.accept()
         else:
             QMessageBox.warning(self, "Licencia", "Clave invalida. Verifique e intente nuevamente.")
+
+    def _copy_id(self):
+        QGuiApplication.clipboard().setText(self._code)
+        QMessageBox.information(self, "Copiar ID", "ID copiado al portapapeles")
+


### PR DESCRIPTION
## Summary
- avoid stale counter.dat when key.dat is missing
- ensure license generator scripts work from repo root
- add copy ID button in activation dialog
- make activation accept keys case-insensitively

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c66b36138832ba0cecf694b563956