### PR TITLE
Improved license activation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ python scripts/generate_license.py <codigo> --counter 1
 ```
 
 Ingrese la clave resultante en la ventana de activación. Cada clave es válida
-solo para el equipo que generó el código y para un único contador.
+solo para el equipo que generó el código y para un único contador. El contador
+se incrementa automáticamente después de una activación exitosa y ahora se
+muestra en la misma ventana para facilitar la generación de futuras licencias.
 
 ### Cambios recientes
 

--- a/src/activation.py
+++ b/src/activation.py
@@ -143,3 +143,8 @@ def check_activation() -> bool:
     with open(KEY_FILE) as f:
         stored = _decrypt(f.read().strip())
     return stored == hardware_id()
+
+
+def license_counter() -> int:
+    """Return the current activation counter."""
+    return _read_counter()

--- a/src/activation_dialog.py
+++ b/src/activation_dialog.py
@@ -9,7 +9,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QGuiApplication
 
-from .activation import machine_code, activate
+from .activation import machine_code, activate, license_counter
 
 
 class ActivationDialog(QDialog):
@@ -20,8 +20,10 @@ class ActivationDialog(QDialog):
         self.setWindowTitle("Activar VIGAPP 060")
         self.setModal(True)
         self._code = machine_code()
+        counter = license_counter()
         msg = (
-            f"ID de equipo: {self._code}\n\n"
+            f"ID de equipo: {self._code}\n"
+            f"Contador: {counter}\n\n"
             "Comparta este codigo al contacto para solicitar su clave de "
             "activacion. Si ya la tiene, ingrese la clave y presione Activar."
         )


### PR DESCRIPTION
## Summary
- expose `license_counter` helper in activation module
- show the current counter on the activation dialog
- clarify in README that the counter increments after each activation

## Testing
- `python -m py_compile main.py src/*.py scripts/generate_license.py`
- `python -m py_compile src/activation.py src/activation_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_684c8b1b80c0832bbb8eeb77830be799