### PR TITLE
Reduce formula image size

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -11,7 +11,7 @@ def color_for_diameter(diam):
     return "#000000"
 
 
-def latex_image(latex: str, fontsize: int = 11) -> str:
+def latex_image(latex: str, fontsize: int = 10) -> str:
     """Return an HTML ``<img>`` tag with a LaTeX expression rendered to PNG."""
     fig = Figure(figsize=(0.01, 0.01))
     ax = fig.add_subplot(111)
@@ -21,6 +21,7 @@ def latex_image(latex: str, fontsize: int = 11) -> str:
     fig.savefig(buf, format="png", dpi=300, bbox_inches="tight", transparent=True)
     fig.clf()
     data = base64.b64encode(buf.getvalue()).decode()
-    return f'<img src="data:image/png;base64,{data}"/>'
+    style = "height:1em;vertical-align:middle;"
+    return f'<img src="data:image/png;base64,{data}" style="{style}"/>'
 
 


### PR DESCRIPTION
## Summary
- scale formula images inline with text

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c915d309c832b85265dd1c9bc6b7f