### PR TITLE
Add offline activation example

### DIFF
--- a/local_activation/generador_licencia.py
+++ b/local_activation/generador_licencia.py
@@ -1,0 +1,66 @@
+import hashlib
+import tkinter as tk
+from tkinter import messagebox
+
+SECRET = "MI_SECRETO_2024"
+
+
+def _base36(num: int) -> str:
+    chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    if num == 0:
+        return "0"
+    digits = []
+    while num:
+        num, rem = divmod(num, 36)
+        digits.append(chars[rem])
+    return "".join(reversed(digits))
+
+
+def generar_clave(equipo_id: str) -> str:
+    digest = hashlib.sha256((equipo_id + SECRET).encode()).hexdigest()
+    return _base36(int(digest, 16))[:6].upper()
+
+
+class GeneradorLicencia(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Generador de Licencia")
+        self.geometry("500x200")
+
+        tk.Label(self, text="ID de equipo:").pack(pady=5)
+        self.id_entry = tk.Entry(self, width=40)
+        self.id_entry.pack(pady=5)
+
+        tk.Label(self, text="Clave generada:").pack(pady=5)
+        self.clave_var = tk.StringVar()
+        self.clave_entry = tk.Entry(self, textvariable=self.clave_var, width=40, state="readonly")
+        self.clave_entry.pack(pady=5)
+
+        btn_frame = tk.Frame(self)
+        btn_frame.pack(pady=10)
+
+        tk.Button(btn_frame, text="Generar", command=self._generar).pack(side=tk.LEFT, padx=5)
+        tk.Button(btn_frame, text="Copiar", command=self._copiar).pack(side=tk.LEFT, padx=5)
+        tk.Button(btn_frame, text="Salir", command=self.destroy).pack(side=tk.LEFT, padx=5)
+
+    def _generar(self):
+        equipo_id = self.id_entry.get().strip()
+        if not equipo_id:
+            messagebox.showwarning("Error", "Ingrese el ID")
+            return
+        self.clave_var.set(generar_clave(equipo_id))
+
+    def _copiar(self):
+        clave = self.clave_var.get()
+        if clave:
+            self.clipboard_clear()
+            self.clipboard_append(clave)
+            messagebox.showinfo("Copiar", "Clave copiada al portapapeles")
+
+
+def main():
+    GeneradorLicencia().mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/local_activation/main.py
+++ b/local_activation/main.py
@@ -1,0 +1,85 @@
+import hashlib
+import os
+import subprocess
+import tkinter as tk
+from tkinter import messagebox
+
+SECRET = "MI_SECRETO_2024"
+
+
+def obtener_serial() -> str:
+    if os.name != "nt":
+        return ""
+    try:
+        out = subprocess.check_output([
+            "wmic",
+            "diskdrive",
+            "get",
+            "SerialNumber",
+        ], stderr=subprocess.DEVNULL, text=True)
+        lines = [line.strip() for line in out.splitlines() if line.strip()][1:]
+        return lines[0] if lines else ""
+    except Exception:
+        return ""
+
+
+def _base36(num: int) -> str:
+    chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    if num == 0:
+        return "0"
+    digits = []
+    while num:
+        num, rem = divmod(num, 36)
+        digits.append(chars[rem])
+    return "".join(reversed(digits))
+
+
+def clave_para(serial: str) -> str:
+    digest = hashlib.sha256((serial + SECRET).encode()).hexdigest()
+    return _base36(int(digest, 16))[:6].upper()
+
+
+class VentanaActivacion(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Activacion")
+        self.geometry("400x200")
+
+        self.serial = obtener_serial()
+
+        tk.Label(self, text="ID de equipo:").pack(pady=5)
+        self.id_var = tk.StringVar(value=self.serial)
+        id_entry = tk.Entry(self, textvariable=self.id_var, width=30, state="readonly")
+        id_entry.pack(pady=5)
+
+        tk.Button(self, text="Copiar ID", command=self._copiar).pack(pady=5)
+
+        tk.Label(self, text="Clave de activacion:").pack(pady=5)
+        self.clave_entry = tk.Entry(self, width=20)
+        self.clave_entry.pack(pady=5)
+
+        tk.Button(self, text="Verificar", command=self._verificar).pack(pady=10)
+
+    def _copiar(self):
+        self.clipboard_clear()
+        self.clipboard_append(self.serial)
+        messagebox.showinfo("Copiar", "ID copiado al portapapeles")
+
+    def _verificar(self):
+        clave = self.clave_entry.get().strip().upper()
+        expected = clave_para(self.serial)
+        if clave == expected:
+            messagebox.showinfo("Licencia", "Clave correcta! Programa activado.")
+            self.destroy()
+            # Aqui continuaria el programa principal
+            print("Programa principal...")
+        else:
+            messagebox.showerror("Licencia", "Clave incorrecta")
+
+
+def main():
+    VentanaActivacion().mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a minimal local activation example using tkinter
- includes `generador_licencia.py` key generator and `main.py` sample app

## Testing
- `python local_activation/generador_licencia.py` *(fails: no display)*
- `python local_activation/main.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_684c97b2d7e0832ba133011b6257441e