### PR TITLE
Re-enable license verification

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,11 +5,13 @@ import os
 import sys
 import ctypes
 
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QDialog
 from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtCore import Qt
 
 from src.moment_app import MomentApp
+from src.activation import check_activation
+from src.activation_dialog import ActivationDialog
 
 
 
@@ -30,6 +32,10 @@ def main():
 
     app.setStyle("Fusion")
 
+    if not check_activation():
+        dlg = ActivationDialog()
+        if dlg.exec_() != QDialog.Accepted:
+            return
 
     # Keep a reference to the main window so it isn't garbage collected
     _window = MomentApp()


### PR DESCRIPTION
## Summary
- link main entrypoint to the license activation system

## Testing
- `python -m py_compile main.py src/activation.py src/activation_dialog.py`
- `python -m py_compile main.py $(find src -name '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_684c9c9c1414832bae211d952d7a4394