### PR TITLE
Switch to local activation module

### DIFF
--- a/local_activation/__init__.py
+++ b/local_activation/__init__.py
@@ -1,0 +1,1 @@
+"""Activacion local por serial."""

--- a/local_activation/main.py
+++ b/local_activation/main.py
@@ -44,6 +44,7 @@ class VentanaActivacion(tk.Tk):
         super().__init__()
         self.title("Activacion")
         self.geometry("400x200")
+        self.activated = False
 
         self.serial = obtener_serial()
 
@@ -70,16 +71,18 @@ class VentanaActivacion(tk.Tk):
         expected = clave_para(self.serial)
         if clave == expected:
             messagebox.showinfo("Licencia", "Clave correcta! Programa activado.")
+            self.activated = True
             self.destroy()
-            # Aqui continuaria el programa principal
-            print("Programa principal...")
         else:
             messagebox.showerror("Licencia", "Clave incorrecta")
 
 
-def main():
-    VentanaActivacion().mainloop()
+def run_activation() -> bool:
+    """Show the activation dialog and return ``True`` if validated."""
+    win = VentanaActivacion()
+    win.mainloop()
+    return win.activated
 
 
 if __name__ == "__main__":
-    main()
+    run_activation()

--- a/main.py
+++ b/main.py
@@ -5,13 +5,12 @@ import os
 import sys
 import ctypes
 
-from PyQt5.QtWidgets import QApplication, QDialog
+from PyQt5.QtWidgets import QApplication
 from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtCore import Qt
 
 from src.moment_app import MomentApp
-from src.activation import check_activation
-from src.activation_dialog import ActivationDialog
+from local_activation.main import run_activation
 
 
 
@@ -19,6 +18,10 @@ from src.activation_dialog import ActivationDialog
 def main():
     """Start the Qt application."""
     logging.basicConfig(level=logging.ERROR)
+
+    if not run_activation():
+        return
+
     if os.name == "nt":
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("VigApp060")
     app = QApplication(sys.argv)
@@ -31,11 +34,6 @@ def main():
 
 
     app.setStyle("Fusion")
-
-    if not check_activation():
-        dlg = ActivationDialog()
-        if dlg.exec_() != QDialog.Accepted:
-            return
 
     # Keep a reference to the main window so it isn't garbage collected
     _window = MomentApp()


### PR DESCRIPTION
## Summary
- use activation logic from `local_activation` package
- expose a `run_activation()` helper
- call this helper in the app's entry point

## Testing
- `python -m py_compile main.py local_activation/main.py local_activation/generador_licencia.py`


------
https://chatgpt.com/codex/tasks/task_e_684c9e24d1bc832bbfda8c59a7ba6644