### PR TITLE
Make activation persistent

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtCore import Qt
 
 from src.moment_app import MomentApp
-from local_activation.main import run_activation
+from src.activation_dialog import run_activation
 
 
 

--- a/src/activation_dialog.py
+++ b/src/activation_dialog.py
@@ -9,7 +9,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QGuiApplication
 
-from .activation import machine_code, activate, license_counter
+from .activation import machine_code, activate, check_activation, license_counter
 
 
 class ActivationDialog(QDialog):
@@ -75,4 +75,12 @@ class ActivationDialog(QDialog):
     def _copy_id(self):
         QGuiApplication.clipboard().setText(self._code)
         QMessageBox.information(self, "Copiar ID", "ID copiado al portapapeles")
+
+
+def run_activation(parent=None) -> bool:
+    """Return ``True`` if the application is activated."""
+    if check_activation():
+        return True
+    dialog = ActivationDialog(parent)
+    return dialog.exec_() == QDialog.Accepted
 


### PR DESCRIPTION
## Summary
- connect main entry point to PyQt activation dialog
- add `run_activation` helper that checks stored license

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca0ede060832bbf77b8a5386467fe