### PR TITLE
Add main menu with splash screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ El sistema es liviano, local y adecuado para versiones beta.
   hacia arriba y los positivos hacia abajo, respetando su posición habitual.
 - La función `correct_moments` aplica ahora los mínimos por cara y global
   siguiendo los criterios de Dual 1 y Dual 2.
+- Se añadió una pantalla de carga inicial y un menú principal unificado.
 
 ## Desarrollo de Refuerzo
 

--- a/main.py
+++ b/main.py
@@ -5,11 +5,11 @@ import os
 import sys
 import ctypes
 
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QSplashScreen
 from PyQt5.QtGui import QIcon, QPixmap
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 
-from src.moment_app import MomentApp
+from src.menu_window import MenuWindow
 from local_activation.main import run_activation
 
 
@@ -35,8 +35,19 @@ def main():
 
     app.setStyle("Fusion")
 
-    # Keep a reference to the main window so it isn't garbage collected
-    _window = MomentApp()
+    splash = None
+    if os.path.exists(icon_path):
+        splash_pix = QPixmap(icon_path).scaled(256, 256, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        splash = QSplashScreen(splash_pix)
+        splash.show()
+
+    def start_main():
+        if splash:
+            splash.close()
+        main_win = MenuWindow()
+        main_win.show()
+
+    QTimer.singleShot(2000, start_main)
     sys.exit(app.exec_())
 
 

--- a/src/memoria_window.py
+++ b/src/memoria_window.py
@@ -17,8 +17,9 @@ from PyQt5.QtPrintSupport import QPrinter
 class MemoriaWindow(QMainWindow):
     """Window showing detailed calculation memory."""
 
-    def __init__(self, title: str, text: str):
+    def __init__(self, title: str, text: str, main=None):
         super().__init__()
+        self.main = main
         self.setWindowTitle(title)
         self.resize(700, 900)
 
@@ -36,10 +37,13 @@ class MemoriaWindow(QMainWindow):
 
         self.btn_capture = QPushButton("Capturar Memoria")
         self.btn_export = QPushButton("Exportar…")
+        self.btn_menu = QPushButton("Ir al Menú")
         self.btn_capture.clicked.connect(self._capture)
         self.btn_export.clicked.connect(self.export)
+        self.btn_menu.clicked.connect(self._to_menu)
         layout.addWidget(self.btn_capture)
         layout.addWidget(self.btn_export)
+        layout.addWidget(self.btn_menu)
 
     def _capture(self):
         pix = self.centralWidget().grab()
@@ -75,4 +79,8 @@ class MemoriaWindow(QMainWindow):
             self.text.document().print_(printer)
         else:
             pix.save(path)
+
+    def _to_menu(self):
+        if self.main:
+            self.main.show_menu()
 

--- a/src/menu_window.py
+++ b/src/menu_window.py
@@ -1,0 +1,164 @@
+from PyQt5.QtWidgets import (
+    QMainWindow, QWidget, QVBoxLayout, QLabel, QPushButton, QStackedWidget,
+    QMessageBox
+)
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtCore import Qt
+import os
+
+from .moment_app import MomentApp
+from .design_window import DesignWindow
+from .view3d_window import View3DWindow
+from .memoria_window import MemoriaWindow
+
+
+class MenuWindow(QMainWindow):
+    """Main container window with navigation."""
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("VIGAPP060")
+        central = QWidget()
+        self.setCentralWidget(central)
+        layout = QVBoxLayout(central)
+        self.stack = QStackedWidget()
+        layout.addWidget(self.stack)
+
+        # Menu page -----------------------------------------------------
+        self.menu_page = QWidget()
+        menu_layout = QVBoxLayout(self.menu_page)
+        menu_layout.setAlignment(Qt.AlignCenter)
+        icon_path = os.path.join(os.path.dirname(__file__), "..", "icon", "vigapp060.png")
+        if os.path.exists(icon_path):
+            lbl_icon = QLabel()
+            pix = QPixmap(icon_path).scaled(128, 128, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+            lbl_icon.setPixmap(pix)
+            lbl_icon.setAlignment(Qt.AlignCenter)
+            menu_layout.addWidget(lbl_icon)
+        title = QLabel("VIGAPP060")
+        title.setAlignment(Qt.AlignCenter)
+        title.setStyleSheet("font-size: 20pt; font-weight: bold;")
+        menu_layout.addWidget(title)
+        self.btn_diag = QPushButton("Diagrama de Momentos")
+        self.btn_design = QPushButton("Diseño de Acero")
+        self.btn_ref = QPushButton("Desarrollo de Refuerzo")
+        self.btn_mem = QPushButton("Memoria de Cálculo")
+        self.btn_clear = QPushButton("Limpiar Datos")
+        for b in (self.btn_diag, self.btn_design, self.btn_ref, self.btn_mem, self.btn_clear):
+            menu_layout.addWidget(b)
+        self.btn_diag.clicked.connect(self.show_diagrama)
+        self.btn_design.clicked.connect(self.show_design)
+        self.btn_ref.clicked.connect(self.show_refuerzo)
+        self.btn_mem.clicked.connect(self.show_memoria)
+        self.btn_clear.clicked.connect(self._clear_data)
+        self.stack.addWidget(self.menu_page)
+
+        # Pages ---------------------------------------------------------
+        self.moment_page = MomentApp(main=self)
+        self.moment_page.setParent(self)
+        self.moment_page.setWindowFlags(Qt.Widget)
+        self.stack.addWidget(self.moment_page)
+
+        self.design_page = DesignWindow([], [], main=self)
+        self.design_page.setParent(self)
+        self.design_page.setWindowFlags(Qt.Widget)
+        self.stack.addWidget(self.design_page)
+
+        self.view3d_page = None
+        self.memoria_page = None
+
+        self.mn_corr = None
+        self.mp_corr = None
+        self.design_done = False
+        self.ref_done = False
+
+        self.show_menu()
+
+    # Navigation helpers -----------------------------------------------
+    def show_menu(self):
+        self.stack.setCurrentWidget(self.menu_page)
+
+    def show_diagrama(self):
+        self.stack.setCurrentWidget(self.moment_page)
+
+    def open_design(self, mn_corr, mp_corr):
+        self.mn_corr = mn_corr
+        self.mp_corr = mp_corr
+        self.design_page.set_moments(mn_corr, mp_corr)
+        self.stack.setCurrentWidget(self.design_page)
+
+    def show_design(self):
+        if self.mn_corr is None:
+            QMessageBox.warning(self, "Advertencia", "Defina primero el diagrama")
+            return
+        self.design_page.set_moments(self.mn_corr, self.mp_corr)
+        self.stack.setCurrentWidget(self.design_page)
+
+    def open_refuerzo(self, design):
+        if not self.design_done:
+            QMessageBox.warning(self, "Advertencia", "Guarde el diseño primero")
+            return
+        if self.view3d_page is None:
+            self.view3d_page = View3DWindow(design, main=self)
+            self.view3d_page.setParent(self)
+            self.view3d_page.setWindowFlags(Qt.Widget)
+            self.stack.addWidget(self.view3d_page)
+        self.stack.setCurrentWidget(self.view3d_page)
+
+    def show_refuerzo(self):
+        if not self.design_done:
+            QMessageBox.warning(self, "Advertencia", "Guarde el diseño primero")
+            return
+        if self.view3d_page is None:
+            self.view3d_page = View3DWindow(self.design_page, main=self)
+            self.view3d_page.setParent(self)
+            self.view3d_page.setWindowFlags(Qt.Widget)
+            self.stack.addWidget(self.view3d_page)
+        self.stack.setCurrentWidget(self.view3d_page)
+
+    def open_memoria(self, title, text):
+        if self.memoria_page is None:
+            self.memoria_page = MemoriaWindow(title, text, main=self)
+            self.memoria_page.setParent(self)
+            self.memoria_page.setWindowFlags(Qt.Widget)
+            self.stack.addWidget(self.memoria_page)
+        else:
+            self.memoria_page.text.setHtml(text)
+            self.memoria_page.setWindowTitle(title)
+        self.stack.setCurrentWidget(self.memoria_page)
+
+    def open_memoria_from_refuerzo(self):
+        if self.memoria_page:
+            self.stack.setCurrentWidget(self.memoria_page)
+
+    def show_memoria(self):
+        if not self.design_done:
+            QMessageBox.warning(self, "Advertencia", "Guarde el diseño primero")
+            return
+        if self.memoria_page:
+            self.stack.setCurrentWidget(self.memoria_page)
+
+    # Callbacks from pages ---------------------------------------------
+    def diagram_saved(self, mn_corr, mp_corr):
+        self.mn_corr = mn_corr
+        self.mp_corr = mp_corr
+
+    def design_saved(self):
+        self.design_done = True
+
+    def refuerzo_saved(self):
+        self.ref_done = True
+
+    # Utilities --------------------------------------------------------
+    def _clear_data(self):
+        self.mn_corr = None
+        self.mp_corr = None
+        self.design_done = False
+        self.ref_done = False
+        self.moment_page.reset_fields()
+        self.design_page.saved = False
+        if self.view3d_page:
+            self.view3d_page.saved = False
+        if self.memoria_page:
+            self.memoria_page.text.clear()
+        QMessageBox.information(self, "Listo", "Datos limpiados")

--- a/src/view3d_window.py
+++ b/src/view3d_window.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QApplication,
     QLineEdit,
+    QMessageBox,
 )
 from PyQt5.QtGui import QGuiApplication
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
@@ -41,9 +42,11 @@ CLEARANCE = 0.2
 class View3DWindow(QMainWindow):
     """Window that displays beam sections for M1, M2 and M3."""
 
-    def __init__(self, design):
+    def __init__(self, design, main=None):
         super().__init__()
+        self.main = main
         self.design = design
+        self.saved = False
         self.neg_orders = []
         self.pos_orders = []
         self.selected = None
@@ -82,8 +85,17 @@ class View3DWindow(QMainWindow):
         # Place the editable title at the bottom
         layout.addWidget(self.title_edit)
         self.btn_capture = QPushButton("Capturar Vista")
+        self.btn_save = QPushButton("Guardar")
+        self.btn_next = QPushButton("Continuar a Memoria")
+        self.btn_menu = QPushButton("Ir al Menú")
         self.btn_capture.clicked.connect(self._capture_view)
+        self.btn_save.clicked.connect(self.on_save)
+        self.btn_next.clicked.connect(self._continue)
+        self.btn_menu.clicked.connect(self._to_menu)
         layout.addWidget(self.btn_capture)
+        layout.addWidget(self.btn_save)
+        layout.addWidget(self.btn_next)
+        layout.addWidget(self.btn_menu)
 
         self.canvas.mpl_connect("pick_event", self._on_pick)
         self.canvas.mpl_connect("key_press_event", self._on_key)
@@ -418,4 +430,21 @@ class View3DWindow(QMainWindow):
         QApplication.processEvents()
         pix = self.canvas.grab()
         QGuiApplication.clipboard().setPixmap(pix)
+
+    def on_save(self):
+        """Mark reinforcement view as saved."""
+        self.saved = True
+        if self.main:
+            self.main.refuerzo_saved()
+
+    def _continue(self):
+        if not self.saved:
+            QMessageBox.warning(self, "Advertencia", "Guarde primero")
+            return
+        if self.main:
+            self.main.open_memoria_from_refuerzo()
+
+    def _to_menu(self):
+        if self.main:
+            self.main.show_menu()
 


### PR DESCRIPTION
## Summary
- integrate `MenuWindow` with stacked pages
- add splash screen to show the app icon for two seconds
- update window classes with save and navigation hooks
- document menu in the README

## Testing
- `python -m py_compile main.py src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684ca299bc6c832bbce70366382d5661