### PR TITLE
UI restructuration with main menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,11 +5,11 @@ import os
 import sys
 import ctypes
 
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QSplashScreen
 from PyQt5.QtGui import QIcon, QPixmap
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 
-from src.moment_app import MomentApp
+from src.menu_window import MenuWindow
 from local_activation.activacion import run_activation
 
 
@@ -36,8 +36,16 @@ def main():
     if not run_activation():
         return
 
-    # Keep a reference to the main window so it isn't garbage collected
-    _window = MomentApp()
+    splash = QSplashScreen(QPixmap(icon_path).scaled(256, 256, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+    splash.show()
+
+    def show_main():
+        splash.close()
+        main_win = MenuWindow()
+        main_win.show()
+        app._window = main_win
+
+    QTimer.singleShot(2000, show_main)
     sys.exit(app.exec_())
 
 

--- a/src/design_window.py
+++ b/src/design_window.py
@@ -48,14 +48,20 @@ DIAM_CM = {
 class DesignWindow(QMainWindow):
     """Ventana para la etapa de diseño de acero (solo interfaz gráfica)."""
 
-    def __init__(self, mn_corr, mp_corr):
+    def __init__(self, mn_corr, mp_corr, parent=None, *, show_window=True,
+                 next_callback=None, save_callback=None, menu_callback=None):
         """Create the design window using corrected moments."""
-        super().__init__()
+        super().__init__(parent)
         self.mn_corr = mn_corr
         self.mp_corr = mp_corr
+        self.next_callback = next_callback
+        self.save_callback = save_callback
+        self.menu_callback = menu_callback
         self.setWindowTitle("Parte 2 – Diseño de Acero")
         self._build_ui()
         self.resize(700, 900)
+        if show_window:
+            self.show()
 
     def _calc_as_req(self, Mu, fc, b, d, fy, phi):
         """Calculate required steel area for a single moment."""
@@ -276,18 +282,21 @@ class DesignWindow(QMainWindow):
 
         self.btn_capture = QPushButton("Capturar Diseño")
         self.btn_memoria = QPushButton("Memoria de Cálculo")
-        self.btn_view3d = QPushButton("Desarrollo de Refuerzo")
-        self.btn_salir = QPushButton("Salir")
+        self.btn_view3d = QPushButton("Continuar con Desarrollo")
+        self.btn_save = QPushButton("Guardar Diseño")
+        self.btn_menu = QPushButton("Menú")
 
         self.btn_capture.clicked.connect(self._capture_design)
         self.btn_memoria.clicked.connect(self.show_memoria)
-        self.btn_view3d.clicked.connect(self.show_view3d)
-        self.btn_salir.clicked.connect(QApplication.instance().quit)
+        self.btn_view3d.clicked.connect(self.on_next)
+        self.btn_save.clicked.connect(self.on_save)
+        self.btn_menu.clicked.connect(self.on_menu)
 
-        layout.addWidget(self.btn_capture, row_start + 4, 0, 1, 2)
-        layout.addWidget(self.btn_memoria, row_start + 4, 2, 1, 2)
-        layout.addWidget(self.btn_view3d, row_start + 4, 4, 1, 2)
-        layout.addWidget(self.btn_salir,   row_start + 4, 6, 1, 2)
+        layout.addWidget(self.btn_save,    row_start + 4, 0, 1, 2)
+        layout.addWidget(self.btn_capture, row_start + 4, 2, 1, 2)
+        layout.addWidget(self.btn_memoria, row_start + 4, 4, 1, 2)
+        layout.addWidget(self.btn_view3d,  row_start + 4, 6, 1, 2)
+        layout.addWidget(self.btn_menu,    row_start + 4, 8, 1, 2)
 
         for ed in self.edits.values():
             ed.editingFinished.connect(self._redraw)
@@ -502,7 +511,7 @@ class DesignWindow(QMainWindow):
         self.canvas_dist.draw()
 
     def _capture_design(self):
-        widgets = [self.btn_capture, self.btn_memoria, self.btn_view3d, self.btn_salir]
+        widgets = [self.btn_capture, self.btn_memoria, self.btn_view3d, self.btn_save, self.btn_menu]
         for w in widgets:
             w.hide()
         self.repaint()
@@ -633,4 +642,18 @@ class DesignWindow(QMainWindow):
         text = html
         self.mem_win = MemoriaWindow(title, text)
         self.mem_win.show()
+
+    def on_next(self):
+        if self.next_callback:
+            self.next_callback()
+        else:
+            self.show_view3d()
+
+    def on_save(self):
+        if self.save_callback:
+            self.save_callback()
+
+    def on_menu(self):
+        if self.menu_callback:
+            self.menu_callback()
 

--- a/src/memoria_window.py
+++ b/src/memoria_window.py
@@ -17,8 +17,10 @@ from PyQt5.QtPrintSupport import QPrinter
 class MemoriaWindow(QMainWindow):
     """Window showing detailed calculation memory."""
 
-    def __init__(self, title: str, text: str):
-        super().__init__()
+    def __init__(self, title: str, text: str, parent=None, *, show_window=True,
+                 menu_callback=None):
+        super().__init__(parent)
+        self.menu_callback = menu_callback
         self.setWindowTitle(title)
         self.resize(700, 900)
 
@@ -38,8 +40,14 @@ class MemoriaWindow(QMainWindow):
         self.btn_export = QPushButton("Exportar…")
         self.btn_capture.clicked.connect(self._capture)
         self.btn_export.clicked.connect(self.export)
+        self.btn_menu = QPushButton("Menú")
+        self.btn_menu.clicked.connect(self.on_menu)
         layout.addWidget(self.btn_capture)
         layout.addWidget(self.btn_export)
+        layout.addWidget(self.btn_menu)
+
+        if show_window:
+            self.show()
 
     def _capture(self):
         pix = self.centralWidget().grab()
@@ -75,4 +83,8 @@ class MemoriaWindow(QMainWindow):
             self.text.document().print_(printer)
         else:
             pix.save(path)
+        
+    def on_menu(self):
+        if self.menu_callback:
+            self.menu_callback()
 

--- a/src/menu_window.py
+++ b/src/menu_window.py
@@ -1,0 +1,161 @@
+import os
+from PyQt5.QtWidgets import (
+    QMainWindow, QWidget, QVBoxLayout, QPushButton, QLabel, QStackedWidget,
+    QMessageBox
+)
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPixmap, QIcon
+
+from .moment_app import MomentApp
+from .design_window import DesignWindow
+from .view3d_window import View3DWindow
+from .memoria_window import MemoriaWindow
+
+
+class MenuWindow(QMainWindow):
+    """Main application window with a simple stacked menu."""
+
+    def __init__(self):
+        super().__init__()
+        icon_path = os.path.join(os.path.dirname(__file__), "..", "icon", "vigapp060.png")
+        pix = QPixmap(icon_path)
+        if not pix.isNull():
+            self.setWindowIcon(QIcon(pix))
+
+        self.setWindowTitle("VIGAPP060")
+
+        self.stacked = QStackedWidget()
+        self.setCentralWidget(self.stacked)
+
+        self.mn_corr = None
+        self.mp_corr = None
+        self.design_ready = False
+
+        self._build_menu(icon_path)
+
+    # ------------------------------------------------------------------
+    def _build_menu(self, icon_path):
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setAlignment(Qt.AlignCenter)
+        label_icon = QLabel()
+        label_icon.setPixmap(QPixmap(icon_path).scaled(128, 128, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+        label_title = QLabel("VIGAPP060")
+        label_title.setAlignment(Qt.AlignCenter)
+        label_title.setStyleSheet("font-size:20pt;font-weight:bold;")
+        layout.addWidget(label_icon, alignment=Qt.AlignCenter)
+        layout.addWidget(label_title)
+
+        btn_diag = QPushButton("Diagrama de Momentos")
+        btn_design = QPushButton("Diseño de Acero")
+        btn_dev = QPushButton("Desarrollo de Refuerzo")
+        btn_mem = QPushButton("Memoria de Cálculo")
+        btn_clear = QPushButton("Limpiar Datos")
+
+        layout.addWidget(btn_diag)
+        layout.addWidget(btn_design)
+        layout.addWidget(btn_dev)
+        layout.addWidget(btn_mem)
+        layout.addWidget(btn_clear)
+
+        btn_diag.clicked.connect(self.open_diagrama)
+        btn_design.clicked.connect(self.open_diseno)
+        btn_dev.clicked.connect(self.open_desarrollo)
+        btn_mem.clicked.connect(self.open_memoria)
+        btn_clear.clicked.connect(self.clear_data)
+
+        self.menu_page = page
+        self.stacked.addWidget(page)
+        self.stacked.setCurrentWidget(page)
+
+    # ------------------------------------------------------------------
+    def open_diagrama(self):
+        if not hasattr(self, "diagram_page"):
+            self.diagram_page = MomentApp(
+                show_window=False,
+                next_callback=self._diagram_next,
+                save_callback=self._save_diagram,
+                menu_callback=self.show_menu,
+            )
+            self.stacked.addWidget(self.diagram_page)
+        self.stacked.setCurrentWidget(self.diagram_page)
+
+    def _diagram_next(self, mn, mp):
+        self.mn_corr = mn
+        self.mp_corr = mp
+        self.design_ready = False
+        self.open_diseno()
+
+    def _save_diagram(self, mn, mp):
+        self.mn_corr = mn
+        self.mp_corr = mp
+        QMessageBox.information(self, "Guardado", "Momentos guardados")
+
+    # ------------------------------------------------------------------
+    def open_diseno(self):
+        if self.mn_corr is None or self.mp_corr is None:
+            QMessageBox.warning(self, "Advertencia", "Primero defina el diagrama")
+            return
+        if not hasattr(self, "design_page"):
+            self.design_page = DesignWindow(
+                self.mn_corr,
+                self.mp_corr,
+                show_window=False,
+                next_callback=self._design_next,
+                save_callback=self._save_design,
+                menu_callback=self.show_menu,
+            )
+            self.stacked.addWidget(self.design_page)
+        self.stacked.setCurrentWidget(self.design_page)
+
+    def _design_next(self):
+        self.design_ready = True
+        self.open_desarrollo()
+
+    def _save_design(self):
+        self.design_ready = True
+        QMessageBox.information(self, "Guardado", "Diseño guardado")
+
+    # ------------------------------------------------------------------
+    def open_desarrollo(self):
+        if not self.design_ready:
+            QMessageBox.warning(self, "Advertencia", "Primero complete el diseño")
+            return
+        if not hasattr(self, "desarrollo_page"):
+            self.desarrollo_page = View3DWindow(
+                self.design_page,
+                show_window=False,
+                menu_callback=self.show_menu,
+            )
+            self.stacked.addWidget(self.desarrollo_page)
+        self.stacked.setCurrentWidget(self.desarrollo_page)
+
+    # ------------------------------------------------------------------
+    def open_memoria(self):
+        if not self.design_ready:
+            QMessageBox.warning(self, "Advertencia", "Debe completar el diseño")
+            return
+        if not hasattr(self, "mem_page"):
+            try:
+                title = self.design_page.windowTitle()
+            except Exception:
+                title = "Memoria"
+            self.mem_page = MemoriaWindow(
+                title,
+                "",
+                show_window=False,
+                menu_callback=self.show_menu,
+            )
+            self.stacked.addWidget(self.mem_page)
+        self.stacked.setCurrentWidget(self.mem_page)
+
+    # ------------------------------------------------------------------
+    def clear_data(self):
+        self.mn_corr = None
+        self.mp_corr = None
+        self.design_ready = False
+        QMessageBox.information(self, "Datos", "Datos limpiados")
+
+    def show_menu(self):
+        self.stacked.setCurrentWidget(self.menu_page)
+

--- a/src/moment_app.py
+++ b/src/moment_app.py
@@ -1,7 +1,15 @@
 import logging
 from PyQt5.QtWidgets import (
-    QApplication, QMainWindow, QWidget, QGridLayout, QLabel,
-    QLineEdit, QPushButton, QRadioButton, QButtonGroup, QMessageBox
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QGridLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QRadioButton,
+    QButtonGroup,
+    QMessageBox,
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QGuiApplication
@@ -17,14 +25,19 @@ from src.design_window import DesignWindow
 class MomentApp(QMainWindow):
     """Ventana principal para ingresar momentos y graficar diagramas."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, parent=None, *, show_window=True, next_callback=None,
+                 save_callback=None, menu_callback=None):
+        super().__init__(parent)
+        self.next_callback = next_callback
+        self.save_callback = save_callback
+        self.menu_callback = menu_callback
         self.setWindowTitle("Parte 1 – Momentos y Diagramas (NTP E.060)")
         self.mn_corr = None
         self.mp_corr = None
         self._build_ui()
         self.resize(700, 900)
-        self.show()
+        if show_window:
+            self.show()
 
     def _build_ui(self):
         central = QWidget()
@@ -61,12 +74,20 @@ class MomentApp(QMainWindow):
         btn_calc = QPushButton("Calcular Diagramas")
         btn_next = QPushButton("Ir a Diseño de Acero")
         btn_capture = QPushButton("Capturar Diagramas")
+        btn_save = QPushButton("Guardar")
+        btn_menu = QPushButton("Ir al Menú")
+
         btn_calc.clicked.connect(self.on_calculate)
         btn_next.clicked.connect(self.on_next)
         btn_capture.clicked.connect(self._capture_diagram)
+        btn_save.clicked.connect(self.on_save)
+        btn_menu.clicked.connect(self.on_menu)
+
+        layout.addWidget(btn_save, 3, 2)
         layout.addWidget(btn_calc, 3, 3)
         layout.addWidget(btn_next, 3, 4)
         layout.addWidget(btn_capture, 3, 5)
+        layout.addWidget(btn_menu, 3, 6)
 
         self.fig, (self.ax1, self.ax2) = plt.subplots(2, 1, figsize=(6, 5), constrained_layout=True)
         self.canvas = FigureCanvas(self.fig)
@@ -215,8 +236,19 @@ class MomentApp(QMainWindow):
         if self.mn_corr is None or self.mp_corr is None:
             QMessageBox.warning(self, 'Advertencia', 'Primero calcule los momentos corregidos')
             return
-        self.design_win = DesignWindow(self.mn_corr, self.mp_corr)
-        self.design_win.show()
+        if self.next_callback:
+            self.next_callback(self.mn_corr, self.mp_corr)
+        else:
+            self.design_win = DesignWindow(self.mn_corr, self.mp_corr)
+            self.design_win.show()
+
+    def on_save(self):
+        if self.save_callback:
+            self.save_callback(self.mn_corr, self.mp_corr)
+
+    def on_menu(self):
+        if self.menu_callback:
+            self.menu_callback()
 
     def _capture_diagram(self):
         self.canvas.repaint()

--- a/src/view3d_window.py
+++ b/src/view3d_window.py
@@ -41,9 +41,10 @@ CLEARANCE = 0.2
 class View3DWindow(QMainWindow):
     """Window that displays beam sections for M1, M2 and M3."""
 
-    def __init__(self, design):
-        super().__init__()
+    def __init__(self, design, parent=None, *, show_window=True, menu_callback=None):
+        super().__init__(parent)
         self.design = design
+        self.menu_callback = menu_callback
         self.neg_orders = []
         self.pos_orders = []
         self.selected = None
@@ -83,7 +84,10 @@ class View3DWindow(QMainWindow):
         layout.addWidget(self.title_edit)
         self.btn_capture = QPushButton("Capturar Vista")
         self.btn_capture.clicked.connect(self._capture_view)
+        self.btn_menu = QPushButton("Menú")
+        self.btn_menu.clicked.connect(self.on_menu)
         layout.addWidget(self.btn_capture)
+        layout.addWidget(self.btn_menu)
 
         self.canvas.mpl_connect("pick_event", self._on_pick)
         self.canvas.mpl_connect("key_press_event", self._on_key)
@@ -91,6 +95,9 @@ class View3DWindow(QMainWindow):
         self.canvas.mpl_connect("button_release_event", self._on_release)
 
         self.draw_views()
+
+        if show_window:
+            self.show()
 
     def _on_title_change(self, text):
         """Update window title and figure heading."""
@@ -418,4 +425,8 @@ class View3DWindow(QMainWindow):
         QApplication.processEvents()
         pix = self.canvas.grab()
         QGuiApplication.clipboard().setPixmap(pix)
+
+    def on_menu(self):
+        if self.menu_callback:
+            self.menu_callback()
 


### PR DESCRIPTION
## Summary
- add stacked menu window with navigation and data checks
- integrate splash screen and connect to new menu
- add Save/Menu buttons in moment and design windows
- allow embedding of view3d and memoria windows

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_684cab7ff490832b92e1a393f2469d46