### PR TITLE
Update menu layout and remove save buttons

### DIFF
--- a/src/design_window.py
+++ b/src/design_window.py
@@ -59,7 +59,7 @@ class DesignWindow(QMainWindow):
         self.menu_callback = menu_callback
         self.setWindowTitle("Parte 2 – Diseño de Acero")
         self._build_ui()
-        self.resize(700, 900)
+        self.setFixedSize(560, 720)
         if show_window:
             self.show()
 
@@ -283,20 +283,17 @@ class DesignWindow(QMainWindow):
         self.btn_capture = QPushButton("Capturar Diseño")
         self.btn_memoria = QPushButton("Memoria de Cálculo")
         self.btn_view3d = QPushButton("Continuar con Desarrollo")
-        self.btn_save = QPushButton("Guardar Diseño")
         self.btn_menu = QPushButton("Menú")
 
         self.btn_capture.clicked.connect(self._capture_design)
         self.btn_memoria.clicked.connect(self.show_memoria)
         self.btn_view3d.clicked.connect(self.on_next)
-        self.btn_save.clicked.connect(self.on_save)
         self.btn_menu.clicked.connect(self.on_menu)
 
-        layout.addWidget(self.btn_save,    row_start + 4, 0, 1, 2)
-        layout.addWidget(self.btn_capture, row_start + 4, 2, 1, 2)
-        layout.addWidget(self.btn_memoria, row_start + 4, 4, 1, 2)
-        layout.addWidget(self.btn_view3d,  row_start + 4, 6, 1, 2)
-        layout.addWidget(self.btn_menu,    row_start + 4, 8, 1, 2)
+        layout.addWidget(self.btn_capture, row_start + 4, 0, 1, 2)
+        layout.addWidget(self.btn_memoria, row_start + 4, 2, 1, 2)
+        layout.addWidget(self.btn_view3d,  row_start + 4, 4, 1, 2)
+        layout.addWidget(self.btn_menu,    row_start + 4, 6, 1, 2)
 
         for ed in self.edits.values():
             ed.editingFinished.connect(self._redraw)
@@ -511,7 +508,7 @@ class DesignWindow(QMainWindow):
         self.canvas_dist.draw()
 
     def _capture_design(self):
-        widgets = [self.btn_capture, self.btn_memoria, self.btn_view3d, self.btn_save, self.btn_menu]
+        widgets = [self.btn_capture, self.btn_memoria, self.btn_view3d, self.btn_menu]
         for w in widgets:
             w.hide()
         self.repaint()

--- a/src/formula_window.py
+++ b/src/formula_window.py
@@ -51,7 +51,7 @@ class FormulaWindow(QMainWindow):
         }
 
         self._build_ui()
-        self.resize(600, 350)
+        self.setFixedSize(560, 720)
 
     def _build_ui(self):
         central = QWidget()

--- a/src/memoria_window.py
+++ b/src/memoria_window.py
@@ -22,7 +22,7 @@ class MemoriaWindow(QMainWindow):
         super().__init__(parent)
         self.menu_callback = menu_callback
         self.setWindowTitle(title)
-        self.resize(700, 900)
+        self.setFixedSize(560, 720)
 
         central = QWidget()
         self.setCentralWidget(central)

--- a/src/menu_window.py
+++ b/src/menu_window.py
@@ -1,7 +1,7 @@
 import os
 from PyQt5.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QPushButton, QLabel, QStackedWidget,
-    QMessageBox
+    QMessageBox, QSizePolicy
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPixmap, QIcon
@@ -27,6 +27,8 @@ class MenuWindow(QMainWindow):
         self.stacked = QStackedWidget()
         self.setCentralWidget(self.stacked)
 
+        self.setFixedSize(560, 720)
+
         self.mn_corr = None
         self.mp_corr = None
         self.design_ready = False
@@ -46,23 +48,24 @@ class MenuWindow(QMainWindow):
         layout.addWidget(label_icon, alignment=Qt.AlignCenter)
         layout.addWidget(label_title)
 
-        btn_diag = QPushButton("Diagrama de Momentos")
-        btn_design = QPushButton("Diseño de Acero")
-        btn_dev = QPushButton("Desarrollo de Refuerzo")
+        btn_flex = QPushButton("Diseño por Flexión")
+        btn_cort = QPushButton("Diseño por Cortante")
         btn_mem = QPushButton("Memoria de Cálculo")
-        btn_clear = QPushButton("Limpiar Datos")
+        btn_exit = QPushButton("Salir")
 
-        layout.addWidget(btn_diag)
-        layout.addWidget(btn_design)
-        layout.addWidget(btn_dev)
+        for b in (btn_flex, btn_cort, btn_mem, btn_exit):
+            b.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+            b.setStyleSheet("font-size:16pt;padding:20px;")
+
+        layout.addWidget(btn_flex)
+        layout.addWidget(btn_cort)
         layout.addWidget(btn_mem)
-        layout.addWidget(btn_clear)
+        layout.addWidget(btn_exit)
 
-        btn_diag.clicked.connect(self.open_diagrama)
-        btn_design.clicked.connect(self.open_diseno)
-        btn_dev.clicked.connect(self.open_desarrollo)
+        btn_flex.clicked.connect(self.open_diagrama)
+        btn_cort.clicked.connect(self.show_cortante_msg)
         btn_mem.clicked.connect(self.open_memoria)
-        btn_clear.clicked.connect(self.clear_data)
+        btn_exit.clicked.connect(self.close)
 
         self.menu_page = page
         self.stacked.addWidget(page)
@@ -74,7 +77,6 @@ class MenuWindow(QMainWindow):
             self.diagram_page = MomentApp(
                 show_window=False,
                 next_callback=self._diagram_next,
-                save_callback=self._save_diagram,
                 menu_callback=self.show_menu,
             )
             self.stacked.addWidget(self.diagram_page)
@@ -85,11 +87,6 @@ class MenuWindow(QMainWindow):
         self.mp_corr = mp
         self.design_ready = False
         self.open_diseno()
-
-    def _save_diagram(self, mn, mp):
-        self.mn_corr = mn
-        self.mp_corr = mp
-        QMessageBox.information(self, "Guardado", "Momentos guardados")
 
     # ------------------------------------------------------------------
     def open_diseno(self):
@@ -102,7 +99,6 @@ class MenuWindow(QMainWindow):
                 self.mp_corr,
                 show_window=False,
                 next_callback=self._design_next,
-                save_callback=self._save_design,
                 menu_callback=self.show_menu,
             )
             self.stacked.addWidget(self.design_page)
@@ -112,11 +108,6 @@ class MenuWindow(QMainWindow):
         self.design_ready = True
         self.open_desarrollo()
 
-    def _save_design(self):
-        self.design_ready = True
-        QMessageBox.information(self, "Guardado", "Diseño guardado")
-
-    # ------------------------------------------------------------------
     def open_desarrollo(self):
         if not self.design_ready:
             QMessageBox.warning(self, "Advertencia", "Primero complete el diseño")
@@ -148,6 +139,9 @@ class MenuWindow(QMainWindow):
             )
             self.stacked.addWidget(self.mem_page)
         self.stacked.setCurrentWidget(self.mem_page)
+
+    def show_cortante_msg(self):
+        QMessageBox.information(self, "En desarrollo", "Módulo en desarrollo")
 
     # ------------------------------------------------------------------
     def clear_data(self):

--- a/src/moment_app.py
+++ b/src/moment_app.py
@@ -35,7 +35,7 @@ class MomentApp(QMainWindow):
         self.mn_corr = None
         self.mp_corr = None
         self._build_ui()
-        self.resize(700, 900)
+        self.setFixedSize(560, 720)
         if show_window:
             self.show()
 
@@ -74,20 +74,17 @@ class MomentApp(QMainWindow):
         btn_calc = QPushButton("Calcular Diagramas")
         btn_next = QPushButton("Ir a Diseño de Acero")
         btn_capture = QPushButton("Capturar Diagramas")
-        btn_save = QPushButton("Guardar")
         btn_menu = QPushButton("Ir al Menú")
 
         btn_calc.clicked.connect(self.on_calculate)
         btn_next.clicked.connect(self.on_next)
         btn_capture.clicked.connect(self._capture_diagram)
-        btn_save.clicked.connect(self.on_save)
         btn_menu.clicked.connect(self.on_menu)
 
-        layout.addWidget(btn_save, 3, 2)
-        layout.addWidget(btn_calc, 3, 3)
-        layout.addWidget(btn_next, 3, 4)
-        layout.addWidget(btn_capture, 3, 5)
-        layout.addWidget(btn_menu, 3, 6)
+        layout.addWidget(btn_calc, 3, 2)
+        layout.addWidget(btn_next, 3, 3)
+        layout.addWidget(btn_capture, 3, 4)
+        layout.addWidget(btn_menu, 3, 5)
 
         self.fig, (self.ax1, self.ax2) = plt.subplots(2, 1, figsize=(6, 5), constrained_layout=True)
         self.canvas = FigureCanvas(self.fig)

--- a/src/view3d_window.py
+++ b/src/view3d_window.py
@@ -57,7 +57,7 @@ class View3DWindow(QMainWindow):
             b = h = 0
         default_title = f"SECCION DE VIGA {int(b)}X{int(h)}" if b and h else "SECCION DE VIGA"
         self.setWindowTitle(default_title)
-        self.resize(800, 600)
+        self.setFixedSize(560, 720)
 
         rng = np.random.default_rng(0)
         # Slightly darker texture for a gray concrete look


### PR DESCRIPTION
## Summary
- simplify main menu with four large options
- remove save buttons from moment and design windows
- fix window dimensions to 560x720 across the app
- adjust capture routines after removing save buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cb00c6f18832b8ebfc5be85311962