### PR TITLE
Update UI sizes and memory display

### DIFF
--- a/src/design_window.py
+++ b/src/design_window.py
@@ -59,7 +59,7 @@ class DesignWindow(QMainWindow):
         self.menu_callback = menu_callback
         self.setWindowTitle("Parte 2 – Diseño de Acero")
         self._build_ui()
-        self.setFixedSize(560, 720)
+        self.setFixedSize(700, 900)
         if show_window:
             self.show()
 
@@ -526,6 +526,12 @@ class DesignWindow(QMainWindow):
 
     def show_memoria(self):
         """Show a detailed calculation window."""
+        title, text = self._build_memoria()
+        self.mem_win = MemoriaWindow(title, text)
+        self.mem_win.show()
+
+    def _build_memoria(self):
+        """Return title and HTML for the calculation memory."""
         try:
             b = float(self.edits["b (cm)"].text())
             h = float(self.edits["h (cm)"].text())
@@ -537,7 +543,7 @@ class DesignWindow(QMainWindow):
             db = DIAM_CM.get(self.cb_varilla.currentText(), 0)
         except ValueError:
             QMessageBox.warning(self, "Error", "Datos num\u00e9ricos inv\u00e1lidos")
-            return
+            return None, None
 
         d = h - r - de - 0.5 * db
         beta1 = 0.85 if fc <= 280 else 0.85 - ((fc - 280) / 70) * 0.05
@@ -556,6 +562,9 @@ class DesignWindow(QMainWindow):
         num_as_max = "0.85 f'c \\beta_1"
 
         lines = [
+            "<h1>DISE\u00d1O DE VIGAS</h1>",
+            "<h2>Datos de la viga del dise\u00f1o a flexi\u00f3n &gt; Dise\u00f1o de Acero</h2>",
+            "<h2>DISE\u00d1O A FLEXI\u00d3N</h2>",
             "<h2>DATOS INGRESADOS</h2>",
             f"<p>b = {b} cm</p>",
             f"<p>h = {h} cm</p>",
@@ -636,9 +645,7 @@ class DesignWindow(QMainWindow):
             "</body></html>"
         )
         title = f"DISE\u00d1O DE VIGA {int(b)}X{int(h)}"
-        text = html
-        self.mem_win = MemoriaWindow(title, text)
-        self.mem_win.show()
+        return title, html
 
     def on_next(self):
         if self.next_callback:

--- a/src/formula_window.py
+++ b/src/formula_window.py
@@ -51,7 +51,7 @@ class FormulaWindow(QMainWindow):
         }
 
         self._build_ui()
-        self.setFixedSize(560, 720)
+        self.setFixedSize(700, 900)
 
     def _build_ui(self):
         central = QWidget()

--- a/src/memoria_window.py
+++ b/src/memoria_window.py
@@ -22,7 +22,7 @@ class MemoriaWindow(QMainWindow):
         super().__init__(parent)
         self.menu_callback = menu_callback
         self.setWindowTitle(title)
-        self.setFixedSize(560, 720)
+        self.setFixedSize(700, 900)
 
         central = QWidget()
         self.setCentralWidget(central)

--- a/src/menu_window.py
+++ b/src/menu_window.py
@@ -27,7 +27,7 @@ class MenuWindow(QMainWindow):
         self.stacked = QStackedWidget()
         self.setCentralWidget(self.stacked)
 
-        self.setFixedSize(560, 720)
+        self.setFixedSize(700, 900)
 
         self.mn_corr = None
         self.mp_corr = None
@@ -49,20 +49,23 @@ class MenuWindow(QMainWindow):
         layout.addWidget(label_title)
 
         btn_flex = QPushButton("Diseño por Flexión")
+        btn_flex_extra = QPushButton("Otro Diseño")
         btn_cort = QPushButton("Diseño por Cortante")
         btn_mem = QPushButton("Memoria de Cálculo")
         btn_exit = QPushButton("Salir")
 
-        for b in (btn_flex, btn_cort, btn_mem, btn_exit):
+        for b in (btn_flex, btn_flex_extra, btn_cort, btn_mem, btn_exit):
             b.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
             b.setStyleSheet("font-size:16pt;padding:20px;")
 
         layout.addWidget(btn_flex)
+        layout.addWidget(btn_flex_extra)
         layout.addWidget(btn_cort)
         layout.addWidget(btn_mem)
         layout.addWidget(btn_exit)
 
         btn_flex.clicked.connect(self.open_diagrama)
+        btn_flex_extra.clicked.connect(self.show_cortante_msg)
         btn_cort.clicked.connect(self.show_cortante_msg)
         btn_mem.clicked.connect(self.open_memoria)
         btn_exit.clicked.connect(self.close)
@@ -126,18 +129,20 @@ class MenuWindow(QMainWindow):
         if not self.design_ready:
             QMessageBox.warning(self, "Advertencia", "Debe completar el diseño")
             return
+        title, html = self.design_page._build_memoria()
+        if title is None:
+            return
         if not hasattr(self, "mem_page"):
-            try:
-                title = self.design_page.windowTitle()
-            except Exception:
-                title = "Memoria"
             self.mem_page = MemoriaWindow(
                 title,
-                "",
+                html,
                 show_window=False,
                 menu_callback=self.show_menu,
             )
             self.stacked.addWidget(self.mem_page)
+        else:
+            self.mem_page.setWindowTitle(title)
+            self.mem_page.text.setHtml(html)
         self.stacked.setCurrentWidget(self.mem_page)
 
     def show_cortante_msg(self):

--- a/src/moment_app.py
+++ b/src/moment_app.py
@@ -35,7 +35,7 @@ class MomentApp(QMainWindow):
         self.mn_corr = None
         self.mp_corr = None
         self._build_ui()
-        self.setFixedSize(560, 720)
+        self.setFixedSize(700, 900)
         if show_window:
             self.show()
 

--- a/src/view3d_window.py
+++ b/src/view3d_window.py
@@ -57,7 +57,7 @@ class View3DWindow(QMainWindow):
             b = h = 0
         default_title = f"SECCION DE VIGA {int(b)}X{int(h)}" if b and h else "SECCION DE VIGA"
         self.setWindowTitle(default_title)
-        self.setFixedSize(560, 720)
+        self.setFixedSize(700, 900)
 
         rng = np.random.default_rng(0)
         # Slightly darker texture for a gray concrete look


### PR DESCRIPTION
## Summary
- enlarge application windows to 700x900
- include extra button placeholder in the main menu
- generate flexural design memory as reusable HTML
- show flexural design memory from the menu
- prepend detailed titles to the memory report

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cb3af0544832b996bced1296f85ad