### PR TITLE
Fix tests to import vigapp modules

### DIFF
--- a/tests/test_design_window.py
+++ b/tests/test_design_window.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from src.ui.design_window import DesignWindow
+from vigapp.ui.design_window import DesignWindow
 
 
 def test_calc_as_req_sample():

--- a/tests/test_moment_app.py
+++ b/tests/test_moment_app.py
@@ -3,7 +3,7 @@ import sys
 import numpy as np
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from src.ui.moment_app import MomentApp
+from vigapp.ui.moment_app import MomentApp
 
 
 def test_correct_moments_dual1_dual2():


### PR DESCRIPTION
## Summary
- adjust tests to import GUI modules from `vigapp` package
- ensure tests run using new imports

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7a0890f0832bbd7f5d45df4a8a0b