### PR TITLE
Update button label and reduce formula size

### DIFF
--- a/src/vigapp/models/utils.py
+++ b/src/vigapp/models/utils.py
@@ -11,7 +11,7 @@ def color_for_diameter(diam):
     return "#000000"
 
 
-def latex_image(latex: str, fontsize: int = 10) -> str:
+def latex_image(latex: str, fontsize: int = 9) -> str:
     """Return an HTML ``<img>`` tag with a LaTeX expression rendered to PNG."""
     fig = Figure(figsize=(0.01, 0.01))
     ax = fig.add_subplot(111)
@@ -21,7 +21,7 @@ def latex_image(latex: str, fontsize: int = 10) -> str:
     fig.savefig(buf, format="png", dpi=300, bbox_inches="tight", transparent=True)
     fig.clf()
     data = base64.b64encode(buf.getvalue()).decode()
-    style = "height:1em;vertical-align:middle;"
+    style = "height:0.9em;vertical-align:middle;"
     return f'<img src="data:image/png;base64,{data}" style="{style}"/>'
 
 

--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -259,7 +259,7 @@ class DesignWindow(QMainWindow):
         layout.addLayout(self.combo_grid, row_start + 3, 0, 1, 8)
 
         self.btn_capture = QPushButton("Capturar Diseño")
-        self.btn_memoria = QPushButton("Memoria de Cálculo")
+        self.btn_memoria = QPushButton("REPORTES")
         self.btn_view3d = QPushButton("Continuar con Desarrollo")
         self.btn_menu = QPushButton("Menú")
 


### PR DESCRIPTION
## Summary
- rename `Memoria de Cálculo` button label to `REPORTES`
- use a slightly smaller font when rendering LaTeX formulas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d898a6ac4832b8e616ee6607b2142