### PR TITLE
Adjust design window layout and formula rendering

### DIFF
--- a/src/vigapp/models/utils.py
+++ b/src/vigapp/models/utils.py
@@ -11,7 +11,7 @@ def color_for_diameter(diam):
     return "#000000"
 
 
-def latex_image(latex: str, fontsize: int = 8) -> str:
+def latex_image(latex: str, fontsize: int = 6) -> str:
     """Return an HTML ``<img>`` tag with a LaTeX expression rendered to PNG."""
     fig = Figure(figsize=(0.01, 0.01))
     ax = fig.add_subplot(111)
@@ -21,14 +21,14 @@ def latex_image(latex: str, fontsize: int = 8) -> str:
     fig.savefig(
         buf,
         format="png",
-        dpi=200,
+        dpi=300,
         bbox_inches="tight",
         pad_inches=0.0,
         transparent=True,
     )
     fig.clf()
     data = base64.b64encode(buf.getvalue()).decode()
-    style = "height:0.8em;vertical-align:middle;"
+    style = "height:0.7em;vertical-align:middle;"
     return f'<img src="data:image/png;base64,{data}" style="{style}"/>'
 
 

--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -37,7 +37,7 @@ class DesignWindow(QMainWindow):
         self.menu_callback = menu_callback
         self.setWindowTitle("Parte 2 – Diseño de Acero")
         self._build_ui()
-        self.setFixedSize(700, 900)
+        self.setFixedSize(700, 1000)
         if show_window:
             self.show()
 
@@ -555,7 +555,10 @@ class DesignWindow(QMainWindow):
             "<h2>CÁLCULOS</h2>",
             "<h3>Cálculo del peralte efectivo d</h3>",
             latex_image(
-                f"d = h - r - \\phi_{{estribo}} - {frac('1','2')} \\phi_{{barra}} = {h} - {r} - {de} - {frac('1','2')}\\times {db} = {d:.2f}\\,cm"
+                "d = h - r - \\phi_{estribo} - "
+                f"{frac('1','2')} \\phi_{barra} \\"
+                f"  = {h} - {r} - {de} - {frac('1','2')}\\times {db} \\"
+                f"  = {d:.2f}\\,cm"
             ),
             "<h3>Cálculo de β<sub>1</sub></h3>",
             (


### PR DESCRIPTION
## Summary
- bump `DesignWindow` height
- fine-tune `latex_image` rendering parameters
- format effective depth equation vertically

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8e99a130832b9c1dec4fe6666c39