### PR TITLE
Fix reports button crash and enlarge design window

### DIFF
--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -37,7 +37,7 @@ class DesignWindow(QMainWindow):
         self.menu_callback = menu_callback
         self.setWindowTitle("Parte 2 – Diseño de Acero")
         self._build_ui()
-        self.setFixedSize(700, 1000)
+        self.setFixedSize(700, 1100)
         if show_window:
             self.show()
 
@@ -505,6 +505,8 @@ class DesignWindow(QMainWindow):
     def show_memoria(self):
         """Show a detailed calculation window."""
         title, text = self._build_memoria()
+        if title is None or text is None:
+            return
         self.mem_win = MemoriaWindow(title, text)
         self.mem_win.show()
 


### PR DESCRIPTION
## Summary
- increase design window height to 1100px
- guard against invalid data when opening Reports window

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9186aa1c832ba03083ae41406847