### PR TITLE
UI tweaks and capture button updates

### DIFF
--- a/src/vigapp/models/utils.py
+++ b/src/vigapp/models/utils.py
@@ -13,6 +13,7 @@ def color_for_diameter(diam):
 
 def latex_image(latex: str, fontsize: int = 6) -> str:
     """Return an HTML ``<img>`` tag with a LaTeX expression rendered to PNG."""
+    fontsize = min(fontsize, 6)
     fig = Figure(figsize=(0.01, 0.01))
     ax = fig.add_subplot(111)
     ax.axis("off")
@@ -28,7 +29,8 @@ def latex_image(latex: str, fontsize: int = 6) -> str:
     )
     fig.clf()
     data = base64.b64encode(buf.getvalue()).decode()
-    style = "height:0.7em;vertical-align:middle;"
+    height = fontsize * 0.12
+    style = f"height:{height:.2f}em;vertical-align:middle;"
     return f'<img src="data:image/png;base64,{data}" style="{style}"/>'
 
 

--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -147,6 +147,7 @@ class DesignWindow(QMainWindow):
     def _build_ui(self):
         content = QWidget()
         layout = QGridLayout(content)
+        layout.setVerticalSpacing(15)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -267,9 +268,9 @@ class DesignWindow(QMainWindow):
 
         layout.addLayout(self.combo_grid, row_start + 3, 0, 1, 8)
 
-        self.btn_capture = QPushButton("Capturar Diseño")
+        self.btn_capture = QPushButton("CAPTURA")
         self.btn_memoria = QPushButton("REPORTES")
-        self.btn_view3d = QPushButton("Continuar con Desarrollo")
+        self.btn_view3d = QPushButton("SECCIONES")
         self.btn_menu = QPushButton("Menú")
 
         self.btn_capture.clicked.connect(self._capture_design)

--- a/src/vigapp/ui/memoria_window.py
+++ b/src/vigapp/ui/memoria_window.py
@@ -36,7 +36,7 @@ class MemoriaWindow(QMainWindow):
         self.text.setHtml(text)
         layout.addWidget(self.text)
 
-        self.btn_capture = QPushButton("Capturar Memoria")
+        self.btn_capture = QPushButton("CAPTURA")
         self.btn_export = QPushButton("Exportar…")
         self.btn_capture.clicked.connect(self._capture)
         self.btn_export.clicked.connect(self.export)

--- a/src/vigapp/ui/menu_window.py
+++ b/src/vigapp/ui/menu_window.py
@@ -296,6 +296,7 @@ class MenuWindow(QMainWindow):
                 self.design_page,
                 show_window=False,
                 menu_callback=self.show_menu,
+                back_callback=self.show_design,
             )
             self.stacked.addWidget(self.desarrollo_page)
         self.stacked.setCurrentWidget(self.desarrollo_page)
@@ -320,6 +321,10 @@ class MenuWindow(QMainWindow):
             self.mem_page.setWindowTitle(title)
             self.mem_page.text.setHtml(html)
         self.stacked.setCurrentWidget(self.mem_page)
+
+    def show_design(self):
+        if hasattr(self, "design_page"):
+            self.stacked.setCurrentWidget(self.design_page)
 
     def show_cortante_msg(self):
         QMessageBox.information(self, "En desarrollo", "Módulo en desarrollo")


### PR DESCRIPTION
## Summary
- add spacing in design window layout and rename buttons
- rename capture button on memory window
- overhaul section view: bigger title, edit field and back button
- allow navigation back to design from menu
- tweak latex image height calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da1f3261c832b9e30d117a00bd1c9