### PR TITLE
Enable scrollable design window

### DIFF
--- a/src/ui/design_window.py
+++ b/src/ui/design_window.py
@@ -1,1 +1,25 @@
-from ..vigapp.ui.design_window import *
+"""Wrapper for :mod:`vigapp.ui.design_window` with window sizing fixes."""
+
+from PyQt5.QtWidgets import QScrollArea
+
+# Import the original implementation
+from ..vigapp.ui.design_window import DesignWindow as _BaseDesignWindow
+
+
+class DesignWindow(_BaseDesignWindow):
+    """Design window with scrollable contents and dynamic sizing."""
+
+    def _build_ui(self):
+        super()._build_ui()
+
+        # Ensure the central widget is a scroll area to allow vertical scrolling
+        if not isinstance(self.centralWidget(), QScrollArea):
+            content_widget = self.centralWidget()
+            scroll = QScrollArea()
+            scroll.setWidgetResizable(True)
+            scroll.setWidget(content_widget)
+            self.setCentralWidget(scroll)
+
+        # Allow the window to be resized instead of fixing its size
+        self.resize(700, 1000)
+


### PR DESCRIPTION
## Summary
- wrap design window's contents in a `QScrollArea`
- allow the design window to be resized freely instead of using a fixed size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da533ac38832ba15a69045a974d26