### PR TITLE
Fix View3D window Qt import

### DIFF
--- a/src/vigapp/ui/view3d_window.py
+++ b/src/vigapp/ui/view3d_window.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import (
     QLineEdit,
     QLabel,
 )
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QGuiApplication
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Summary
- fix NameError in `View3DWindow` by importing `Qt`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da68e1450832b8c1ca9b6950ef7e9