### PR TITLE
Fix scroll area for design window

### DIFF
--- a/src/ui/design_window.py
+++ b/src/ui/design_window.py
@@ -1,28 +1,62 @@
 """Wrapper for :mod:`vigapp.ui.design_window` with dynamic sizing fixes."""
 
-from PyQt5.QtWidgets import QScrollArea
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QScrollArea, QLayout
 
 # Import the original implementation
 from ..vigapp.ui.design_window import DesignWindow as _BaseDesignWindow
 
 
-class DesignWindow(_BaseDesignWindow):
-    """Design window with scrollable contents and dynamic sizing."""
+class DesignWindow(QDialog):
+    """Design window displayed inside a resizable scroll area."""
+
+    def __init__(
+        self,
+        mn_corr,
+        mp_corr,
+        parent=None,
+        *,
+        show_window=True,
+        next_callback=None,
+        save_callback=None,
+        menu_callback=None,
+    ):
+        super().__init__(parent)
+
+        # Create the base window without showing it. The resulting scroll
+        # area contains all widgets and layouts built in the original class.
+        self._base = _BaseDesignWindow(
+            mn_corr,
+            mp_corr,
+            None,
+            show_window=False,
+            next_callback=next_callback,
+            save_callback=save_callback,
+            menu_callback=menu_callback,
+        )
+
+        self._build_ui()
+        self.setWindowTitle(self._base.windowTitle())
+        self.resize(self._base.size())
+        if show_window:
+            self.show()
 
     def _build_ui(self):
-        super()._build_ui()
+        # Re-parent the base scroll area to this dialog and ensure it is
+        # resizable. Its internal layout is also configured to use the
+        # minimum required size so the scroll bars appear when necessary.
+        self.scroll_area = self._base.scroll_area
+        self.scroll_area.setParent(self)
+        self.scroll_area.setWidgetResizable(True)
 
-        # Ensure the central widget is wrapped in a scroll area to allow
-        # vertical scrolling when the contents exceed the available height.
-        if not isinstance(self.centralWidget(), QScrollArea):
-            content_widget = self.centralWidget()
-            scroll = QScrollArea()
-            scroll.setWidgetResizable(True)
-            scroll.setWidget(content_widget)
-            self.setCentralWidget(scroll)
+        layout = QVBoxLayout(self)
+        layout.setSizeConstraint(QLayout.SetMinimumSize)
+        layout.addWidget(self.scroll_area)
+        self.setLayout(layout)
 
-        # Do not force any fixed size for the window. The base implementation
-        # may have resized the window, but here we avoid calling ``resize`` or
-        # ``setFixedSize`` so that the geometry adapts naturally to the
-        # available space and scrolls when required.
+        content_layout = self.scroll_area.widget().layout()
+        if content_layout is not None:
+            content_layout.setSizeConstraint(QLayout.SetMinimumSize)
 
+    def __getattr__(self, name):
+        """Delegate attribute access to the underlying window."""
+        return getattr(self._base, name)


### PR DESCRIPTION
## Summary
- expose design screen as a QDialog wrapper
- reparent original scroll area into the dialog
- enforce `QLayout.SetMinimumSize` for better resizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da8589840832bb95b853ccb6ec111