### PR TITLE
Fix flexion design window scroll

### DIFF
--- a/src/ui/design_window.py
+++ b/src/ui/design_window.py
@@ -36,7 +36,6 @@ class DesignWindow(QDialog):
 
         self._build_ui()
         self.setWindowTitle(self._base.windowTitle())
-        self.resize(self._base.size())
         if show_window:
             self.show()
 

--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QScrollArea,
+    QLayout,
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QGuiApplication
@@ -148,6 +149,7 @@ class DesignWindow(QMainWindow):
         content = QWidget()
         layout = QGridLayout(content)
         layout.setVerticalSpacing(15)
+        layout.setSizeConstraint(QLayout.SetMinimumSize)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -155,9 +157,6 @@ class DesignWindow(QMainWindow):
         scroll.setWidget(content)
         self.setCentralWidget(scroll)
         self.scroll_area = scroll
-
-        # Definir un tamaño inicial amplio para evitar contenido oculto
-        self.resize(1200, 800)
 
         labels = [
             ("b (cm)", "30"),


### PR DESCRIPTION
## Summary
- remove fixed window resizing from wrapper
- remove resize and set minimum size constraint in design window
- ensure scroll area resizes and layout uses minimum-size constraint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dac4239ac832bb0d8c88090f91947