### PR TITLE
Increase design window height

### DIFF
--- a/src/ui/design_window.py
+++ b/src/ui/design_window.py
@@ -37,7 +37,7 @@ class DesignWindow(QDialog):
         self._build_ui()
         self.setWindowTitle(self._base.windowTitle())
         # Start with a height large enough to reveal all content
-        self.resize(750, 1250)
+        self.resize(750, 1500)
         if show_window:
             self.show()
 

--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -39,6 +39,8 @@ class DesignWindow(QMainWindow):
         self.menu_callback = menu_callback
         self.setWindowTitle("Parte 2 – Diseño de Acero")
         self._build_ui()
+        # Provide enough vertical space so scrolling is rarely needed
+        self.resize(750, 1500)
         if show_window:
             self.show()
 


### PR DESCRIPTION
## Summary
- allow more vertical space in the design window to avoid excessive scrolling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684db5b32578832b8ead4b1c6561036e