### PR TITLE
Enhance flexural design report formatting

### DIFF
--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -618,15 +618,19 @@ class DesignWindow(QMainWindow):
         def frac(num: str, den: str) -> str:
             return f"\\dfrac{{{num}}}{{{den}}}"
 
+        def eq_steps(*parts: str) -> str:
+            imgs = [latex_image(p) for p in parts]
+            return "<div class='eq'>" + "<br/>".join(imgs) + "</div>"
+
         frac_root_fc_fy = frac("\\sqrt{f'c}", "fy")
         sqrt_fc = f"\\sqrt{{{fc}}}"
         num_as_max = "0.85 f'c \\beta_1"
 
+        title_text = f"Dise\u00f1o a flexi\u00f3n de viga {int(b)}x{int(h)}"
+
         lines = [
-            "<h1>DISE\u00d1O DE VIGAS</h1>",
-            "<h2>Datos de la viga del dise\u00f1o a flexi\u00f3n &gt; Dise\u00f1o de Acero</h2>",
-            "<h2>DISE\u00d1O A FLEXI\u00d3N</h2>",
-            "<h2>DATOS INGRESADOS</h2>",
+            f"<h1>{title_text}</h1>",
+            "<h2>Datos ingresados</h2>",
             f"<p>b = {b} cm</p>",
             f"<p>h = {h} cm</p>",
             f"<p>r = {r} cm</p>",
@@ -635,35 +639,38 @@ class DesignWindow(QMainWindow):
             f"<p>φ = {phi}</p>",
             f"<p>ϕ estribo = {de} cm</p>",
             f"<p>ϕ varilla = {db} cm</p>",
-            "<h2>CÁLCULOS</h2>",
-            "<h3>Cálculo del peralte efectivo d</h3>",
-            latex_image(
-                "d = h - r - \\phi_{estribo} - "
-                f"{frac('1','2')} \\phi_{{barra}} \\"  # Escapar llaves en f-string
-                f"  = {h} - {r} - {de} - {frac('1','2')}\\times {db} \\" 
-                f"  = {d:.2f}\\,cm"
+            "<h2>C\u00e1lculos</h2>",
+            "<h3>Peralte efectivo d</h3>",
+            eq_steps(
+                "d = h - r - \\phi_{estribo} - " + frac('1','2') + " \\phi_{barra}",
+                f"d = {h} - {r} - {de} - {frac('1','2')}\\times {db}",
+                f"d = {d:.2f}\\,cm",
             ),
-            "<h3>Cálculo de β<sub>1</sub></h3>",
+            "<h3>Coeficiente \u03b2<sub>1</sub></h3>",
             (
-                latex_image("\\beta_{1} = 0.85")
+                eq_steps("\\beta_{1} = 0.85")
                 if fc <= 280
-                else latex_image(
-                    f"\\beta_1 = 0.85 - 0.05\\times {frac(f'{fc}-280','70')} = {beta1:.3f}"
+                else eq_steps(
+                    "\\beta_1 = 0.85 - 0.05\\times " + frac(f"{fc}-280", "70"),
+                    f"\\beta_1 = {beta1:.3f}",
                 )
             ),
-            "<h3>Cálculo de As_min</h3>",
-            latex_image(
-                f"A_s,_{{min}} = 0.7\\times {frac_root_fc_fy}\\times b\\times d = 0.7\\times {frac(sqrt_fc, str(fy))}\\times {b}\\times {d:.2f} = {as_min:.2f}\\,cm^2"
+            "<h3>C\u00e1lculo de A_s,\u200bmin</h3>",
+            eq_steps(
+                f"A_s,_{{min}} = 0.7\\times {frac_root_fc_fy}\\times b\\times d",
+                f"A_s,_{{min}} = 0.7\\times {frac(sqrt_fc, str(fy))}\\times {b}\\times {d:.2f}",
+                f"A_s,_{{min}} = {as_min:.2f}\\,cm^2",
             ),
-            "<h3>Cálculo de As_max</h3>",
-            latex_image(
-                f"A_s,_{{max}} = 0.75\\times {frac(num_as_max,'fy')}\\times {frac('6000', f'6000+{fy}')}\\times b\\times d = {as_max:.2f}\\,cm^2"
+            "<h3>C\u00e1lculo de A_s,\u200bmax</h3>",
+            eq_steps(
+                f"A_s,_{{max}} = 0.75\\times {frac(num_as_max,'fy')}\\times {frac('6000', f'6000+{fy}')}\\times b\\times d",
+                f"A_s,_{{max}} = {as_max:.2f}\\,cm^2",
             ),
-            "<h3>Fórmula general para As</h3>",
-            latex_image(
-                fr"A_s = {frac('1.7 f\'c b d','2 fy')} - {frac('1','2')}\sqrt{{{frac('2.89 (f\'c b d)^2','fy^2')} - {frac('6.8 f\'c b M_u','\\phi fy^2')}}}"
+            "<h3>F\u00f3rmula general para A_s</h3>",
+            eq_steps(
+                fr"A_s = {frac('1.7 f\'c b d','2 fy')} - {frac('1','2')}\sqrt{{{frac('2.89 (f\'c b d)^2','fy^2')} - {frac('6.8 f\'c b M_u','\\phi fy^2')}}}",
             ),
-            "<h3>Detalle del cálculo de As por momento</h3>",
+            "<h3>Detalle del c\u00e1lculo de A_s por momento</h3>",
         ]
 
         labels = ["M1-", "M2-", "M3-", "M1+", "M2+", "M3+"]
@@ -686,29 +693,31 @@ class DesignWindow(QMainWindow):
                 f"{frac(f'2.89\\times({fc}\\times{b}\\times{d:.2f})^2', f'{fy}^2')} - "
                 f"{frac(f'6.8\\times{fc}\\times{b}\\times{Mu_kgcm:.0f}', f'{phi}\\times{fy}^2')}"
             )
-            lines.extend(
-                [
-                    f"<p><b>{lab}</b>: M<sub>u</sub> = {m:.2f} TN·m = {Mu_kgcm:.0f} kg·cm</p>",
-                    latex_image(
-                        f"A_s,calc = {term_html} - {frac('1','2')}\\sqrt{{{root_html}}} = {term:.2f} - {frac('1','2')}\\sqrt{{{root:.2f}}} = {calc:.2f}\\,cm^2"
-                    ),
-                    f"<p>A<sub>s,req</sub> = <b>{a:.2f} cm²</b></p>",
-                ]
-            )
+            lines.extend([
+                f"<p><b>{lab}</b>: M<sub>u</sub> = {m:.2f} TN·m = {Mu_kgcm:.0f} kg·cm</p>",
+                eq_steps(
+                    f"A_s,calc = {term_html} - {frac('1','2')}\\sqrt{{{root_html}}}",
+                    f"A_s,calc = {term:.2f} - {frac('1','2')}\\sqrt{{{root:.2f}}}",
+                    f"A_s,calc = {calc:.2f}\\,cm^2",
+                ),
+                f"<p>A<sub>s,req</sub> = <b>{a:.2f} cm²</b></p>",
+            ])
 
         html = (
             "<html><head>"
             "<style>"
             "body{font-size:11pt;font-family:'Times New Roman';}"
-            "h2{font-size:12pt;margin:8px 0;}"
-            "h3{font-size:11pt;margin:6px 0;}"
-            "p{margin:6px 0;} .eq{margin-left:20px;}"
+            "h1{text-align:center;font-size:14pt;margin-bottom:10px;}"
+            "h2{font-size:12pt;margin-top:12px;margin-bottom:6px;border-bottom:1px solid #aaa;}"
+            "h3{font-size:11pt;margin:8px 0 4px 0;}"
+            "p{margin:4px 0 4px 20px;}"
+            ".eq{margin-left:40px;margin-bottom:6px;}"
             "</style>"
             "</head><body>"
             + "\n".join(lines) +
             "</body></html>"
         )
-        title = f"DISE\u00d1O DE VIGA {int(b)}X{int(h)}"
+        title = title_text
         return title, html
 
     def on_next(self):

--- a/src/vigapp/ui/memoria_window.py
+++ b/src/vigapp/ui/memoria_window.py
@@ -6,12 +6,15 @@ from PyQt5.QtWidgets import (
     QMainWindow,
     QWidget,
     QVBoxLayout,
+    QHBoxLayout,
     QPushButton,
     QTextEdit,
     QFileDialog,
+    QInputDialog,
 )
 from PyQt5.QtGui import QGuiApplication
 from PyQt5.QtPrintSupport import QPrinter
+import re
 
 
 class MemoriaWindow(QMainWindow):
@@ -21,6 +24,7 @@ class MemoriaWindow(QMainWindow):
                  menu_callback=None):
         super().__init__(parent)
         self.menu_callback = menu_callback
+        self.html = text
         self.setWindowTitle(title)
         self.setFixedSize(700, 900)
 
@@ -28,23 +32,37 @@ class MemoriaWindow(QMainWindow):
         self.setCentralWidget(central)
         layout = QVBoxLayout(central)
 
+        top = QHBoxLayout()
+        top.addStretch()
+        self.btn_edit_title = QPushButton("Editar título")
+        self.btn_edit_title.clicked.connect(self.edit_title)
+        top.addWidget(self.btn_edit_title)
+        layout.addLayout(top)
+
         self.text = QTextEdit()
         self.text.setReadOnly(True)
         self.text.setFontFamily("Times New Roman")
         self.text.setFontPointSize(11)
         # Text is provided as HTML to allow richer formatting
-        self.text.setHtml(text)
+        self.text.setHtml(self.html)
         layout.addWidget(self.text)
 
         self.btn_capture = QPushButton("CAPTURA")
         self.btn_export = QPushButton("Exportar…")
+        self.btn_menu = QPushButton("Menú")
+        for btn in (self.btn_capture, self.btn_export, self.btn_menu):
+            btn.setFixedWidth(90)
         self.btn_capture.clicked.connect(self._capture)
         self.btn_export.clicked.connect(self.export)
-        self.btn_menu = QPushButton("Menú")
         self.btn_menu.clicked.connect(self.on_menu)
-        layout.addWidget(self.btn_capture)
-        layout.addWidget(self.btn_export)
-        layout.addWidget(self.btn_menu)
+
+        btns = QHBoxLayout()
+        btns.addStretch()
+        btns.addWidget(self.btn_capture)
+        btns.addWidget(self.btn_export)
+        btns.addWidget(self.btn_menu)
+        btns.addStretch()
+        layout.addLayout(btns)
 
         if show_window:
             self.show()
@@ -83,7 +101,15 @@ class MemoriaWindow(QMainWindow):
             self.text.document().print_(printer)
         else:
             pix.save(path)
-        
+
+    def edit_title(self):
+        """Allow user to manually edit the window and header title."""
+        title, ok = QInputDialog.getText(self, "Editar título", "Título:", text=self.windowTitle())
+        if ok and title:
+            self.setWindowTitle(title)
+            self.html = re.sub(r"<h1>.*?</h1>", f"<h1>{title}</h1>", self.html, 1, flags=re.DOTALL)
+            self.text.setHtml(self.html)
+
     def on_menu(self):
         if self.menu_callback:
             self.menu_callback()


### PR DESCRIPTION
## Summary
- improve buttons layout in `MemoriaWindow`
- allow editing the report title
- display flexural design title with beam dimensions
- organize data sections and display formulas step by step
- apply consistent styling in the HTML report

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_684f6b039628832bb5ced9c042346b93