### PR TITLE
Adjust fraction display scale

### DIFF
--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -616,7 +616,8 @@ class DesignWindow(QMainWindow):
         as_p = np.clip(as_p_raw, as_min, as_max)
 
         def frac(num: str, den: str) -> str:
-            return f"\\dfrac{{{num}}}{{{den}}}"
+            """Return a visually compact fraction for LaTeX output."""
+            return f"\\tfrac{{{num}}}{{{den}}}"
 
         def eq_steps(*parts: str) -> str:
             imgs = [latex_image(p) for p in parts]


### PR DESCRIPTION
## Summary
- shrink LaTeX fractions in flexural design reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6d2190c4832b9d9da6fab4a22fa4