### PR TITLE
Migrate memory PDF generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ sympy
 python-docx
 pylatex
 Pillow
-pypi.org
+reportlab

--- a/src/vigapp/pdf_report.py
+++ b/src/vigapp/pdf_report.py
@@ -1,0 +1,49 @@
+"""PDF generation utilities using ReportLab."""
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.platypus import (
+    SimpleDocTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
+    Preformatted,
+)
+
+
+def generate_memoria_pdf(title, data_section, calc_sections, result_section, path):
+    """Create a calculation report as a PDF."""
+    styles = getSampleStyleSheet()
+    doc = SimpleDocTemplate(path, pagesize=letter,
+                            rightMargin=40, leftMargin=40,
+                            topMargin=40, bottomMargin=40)
+
+    story = [Paragraph(title, styles["Title"]), Spacer(1, 12)]
+
+    if data_section:
+        story.append(Paragraph("Datos del proyecto", styles["Heading2"]))
+        table = Table(data_section, hAlign="LEFT")
+        table.setStyle(TableStyle([
+            ("GRID", (0, 0), (-1, -1), 0.5, colors.black),
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ]))
+        story.append(table)
+        story.append(Spacer(1, 12))
+
+    if calc_sections:
+        story.append(Paragraph("Cálculos", styles["Heading2"]))
+        for subtitle, steps in calc_sections:
+            story.append(Paragraph(subtitle, styles["Heading3"]))
+            for step in steps:
+                story.append(Preformatted(step, styles["Code"]))
+            story.append(Spacer(1, 6))
+
+    if result_section:
+        story.append(Paragraph("Resultados", styles["Heading2"]))
+        for text, value in result_section:
+            story.append(Paragraph(f"{text}: {value}", styles["Normal"]))
+
+    doc.build(story)
+    return path

--- a/src/vigapp/ui/memoria_window.py
+++ b/src/vigapp/ui/memoria_window.py
@@ -1,32 +1,31 @@
-"""Window displaying detailed calculation steps."""
+"""Window triggering PDF generation for the calculation memory."""
 
 import os
-import tempfile
 from PyQt5.QtWidgets import (
     QMainWindow,
     QWidget,
     QVBoxLayout,
     QHBoxLayout,
     QPushButton,
-    QTextEdit,
+    QLabel,
     QFileDialog,
     QInputDialog,
 )
-from PyQt5.QtGui import QGuiApplication
-from PyQt5.QtPrintSupport import QPrinter
 import re
+
+from ..pdf_report import generate_memoria_pdf
 
 
 class MemoriaWindow(QMainWindow):
-    """Window showing detailed calculation memory."""
+    """Window used to export the calculation memory as a PDF."""
 
-    def __init__(self, title: str, text: str, parent=None, *, show_window=True,
+    def __init__(self, title: str, data: dict, parent=None, *, show_window=True,
                  menu_callback=None):
         super().__init__(parent)
         self.menu_callback = menu_callback
-        self.html = text
+        self.data = data
         self.setWindowTitle(title)
-        self.setFixedSize(700, 900)
+        self.setFixedSize(500, 200)
 
         central = QWidget()
         self.setCentralWidget(central)
@@ -39,13 +38,10 @@ class MemoriaWindow(QMainWindow):
         top.addWidget(self.btn_edit_title)
         layout.addLayout(top)
 
-        self.text = QTextEdit()
-        self.text.setReadOnly(True)
-        self.text.setFontFamily("Times New Roman")
-        self.text.setFontPointSize(11)
-        # Text is provided as HTML to allow richer formatting
-        self.text.setHtml(self.html)
-        layout.addWidget(self.text)
+        self.label = QLabel(
+            "Presione 'Captura' o 'Exportar…' para guardar la memoria en PDF.")
+        self.label.setWordWrap(True)
+        layout.addWidget(self.label)
 
         self.btn_capture = QPushButton("CAPTURA")
         self.btn_export = QPushButton("Exportar…")
@@ -68,49 +64,45 @@ class MemoriaWindow(QMainWindow):
             self.show()
 
     def _capture(self):
-        pix = self.centralWidget().grab()
-        QGuiApplication.clipboard().setPixmap(pix)
-        # Sin mensaje emergente
-
-    def export(self):
-        """Save the memory view as PNG, PDF or DOCX."""
-        pix = self.centralWidget().grab()
+        """Generate the PDF and ask for a save location."""
         path, _ = QFileDialog.getSaveFileName(
             self,
-            "Guardar como",
-            "",
-            "PNG (*.png);;PDF (*.pdf);;Word (*.docx)",
+            "Guardar PDF",
+            "memoria.pdf",
+            "PDF (*.pdf)",
         )
-        if not path:
-            return
-        ext = os.path.splitext(path)[1].lower()
-        if ext == ".docx":
-            tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
-            tmp.close()
-            pix.save(tmp.name)
-            from docx import Document
+        if path:
+            self._generate(path)
 
-            doc = Document()
-            doc.add_picture(tmp.name)
-            doc.save(path)
-            os.unlink(tmp.name)
-        elif ext == ".pdf":
-            printer = QPrinter(QPrinter.HighResolution)
-            printer.setOutputFormat(QPrinter.PdfFormat)
-            printer.setOutputFileName(path)
-            self.text.document().print_(printer)
-        else:
-            pix.save(path)
+    def export(self):
+        """Generate the PDF and let the user select the destination."""
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Guardar PDF",
+            "memoria.pdf",
+            "PDF (*.pdf)",
+        )
+        if path:
+            self._generate(path)
+
+    def _generate(self, path: str):
+        """Internal helper that builds the PDF using stored data."""
+        generate_memoria_pdf(
+            self.windowTitle(),
+            self.data.get("data_section", []),
+            self.data.get("calc_sections", []),
+            self.data.get("results", []),
+            path,
+        )
 
     def edit_title(self):
         """Allow user to manually edit the window and header title."""
         title, ok = QInputDialog.getText(self, "Editar título", "Título:", text=self.windowTitle())
         if ok and title:
             self.setWindowTitle(title)
-            self.html = re.sub(r"<h1>.*?</h1>", f"<h1>{title}</h1>", self.html, 1, flags=re.DOTALL)
-            self.text.setHtml(self.html)
 
     def on_menu(self):
         if self.menu_callback:
             self.menu_callback()
+
 


### PR DESCRIPTION
## Summary
- add ReportLab based PDF generator
- export memory calculations as PDF
- adapt design_window to provide data for PDF
- update requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f736ece94832b9e86f722a6efe6df