### PR TITLE
Improve flexion report generation with previews

### DIFF
--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -19,6 +19,7 @@ from PyQt5.QtGui import QGuiApplication, QFont
 from .view3d_window import View3DWindow
 from .memoria_window import MemoriaWindow
 from ..models.constants import DIAM_CM, BAR_DATA
+from ..models.utils import capture_widget_temp
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt
 import numpy as np
@@ -681,11 +682,25 @@ class DesignWindow(QMainWindow):
         for lab, val in zip(labels, as_n.tolist() + as_p.tolist()):
             result_section.append((f"As req {lab}", f"{val:.2f} cm²"))
 
+        images = []
+        img = capture_widget_temp(self.canvas_sec, "sec_")
+        if img:
+            images.append(img)
+        try:
+            view = View3DWindow(self, show_window=False)
+            img_view = capture_widget_temp(view.canvas, "view3d_")
+            view.close()
+            if img_view:
+                images.append(img_view)
+        except Exception:
+            pass
+
         title = title_text
         data = {
             "data_section": data_section,
             "calc_sections": calc_sections,
             "results": result_section,
+            "images": images,
         }
         return title, data
 

--- a/src/vigapp/ui/menu_window.py
+++ b/src/vigapp/ui/menu_window.py
@@ -307,20 +307,27 @@ class MenuWindow(QMainWindow):
         if not self.design_ready:
             QMessageBox.warning(self, "Advertencia", "Debe completar el diseño")
             return
-        title, html = self.design_page._build_memoria()
+        title, data = self.design_page._build_memoria()
         if title is None:
             return
+        images = data.get("images", [])
+        if hasattr(self, "diagram_page") and hasattr(self.diagram_page, "canvas"):
+            from ..models.utils import capture_widget_temp
+            img = capture_widget_temp(self.diagram_page.canvas, "diagram_")
+            if img:
+                images.append(img)
+        data["images"] = images
         if not hasattr(self, "mem_page"):
             self.mem_page = MemoriaWindow(
                 title,
-                html,
+                data,
                 show_window=False,
                 menu_callback=self.show_menu,
             )
             self.stacked.addWidget(self.mem_page)
         else:
             self.mem_page.setWindowTitle(title)
-            self.mem_page.text.setHtml(html)
+            self.mem_page.set_data(data)
         self.stacked.setCurrentWidget(self.mem_page)
 
     def show_design(self):


### PR DESCRIPTION
## Summary
- enhance utils with formula parsing, HTML generation and temporary widget capture
- generate design report images and include them in data
- present a full HTML preview in MemoriaWindow before PDF export
- capture diagram images when opening reports from the menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7be5d748832bbf4a5dbb3f6aff46