### PR TITLE
Rediseño PDF de memoria

### DIFF
--- a/src/vigapp/models/utils.py
+++ b/src/vigapp/models/utils.py
@@ -83,6 +83,41 @@ def capture_widget(widget: QWidget, path: str) -> Optional[str]:
 import tempfile
 import re
 import sympy as sp
+from matplotlib.figure import Figure
+
+
+def draw_beam_section_png(b: float, h: float, r: float, de: float, db: float, path: str) -> str:
+    """Draw a simple beam section and save it as PNG."""
+    d = h - r - de - 0.5 * db
+    fig = Figure(figsize=(2.4, 2.4))
+    ax = fig.add_subplot(111)
+    ax.set_aspect("equal")
+    ax.axis("off")
+
+    # Outer rectangle
+    ax.plot([0, b, b, 0, 0], [0, 0, h, h, 0], "k-")
+    # Cover
+    ax.plot([r, b - r, b - r, r, r], [r, r, h - r, h - r, r], "r--")
+    # Stirrup offset
+    off = r + de
+    ax.plot([off, b - off, b - off, off, off], [off, off, h - off, h - off, off], "b:")
+
+    y_d = h - d
+    ax.annotate("", xy=(0, -5), xytext=(b, -5), arrowprops=dict(arrowstyle="<->"))
+    ax.text(b / 2, -6, f"b = {b:.0f} cm", ha="center", va="top", fontsize=6)
+
+    ax.annotate("", xy=(-5, h), xytext=(-5, y_d), arrowprops=dict(arrowstyle="<->"))
+    ax.text(-6, (h + y_d) / 2, f"d = {d:.1f} cm", ha="right", va="center", rotation=90, fontsize=6)
+
+    ax.annotate("", xy=(-12, 0), xytext=(-12, h), arrowprops=dict(arrowstyle="<->"))
+    ax.text(-13, h / 2, f"h = {h:.0f} cm", ha="right", va="center", rotation=90, fontsize=6)
+
+    ax.set_xlim(-15, b + 10)
+    ax.set_ylim(-10, h + 10)
+
+    fig.savefig(path, dpi=300, bbox_inches="tight")
+    fig.clf()
+    return path
 
 
 def parse_formula(text: str):

--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -615,7 +615,7 @@ class DesignWindow(QMainWindow):
         as_n = np.clip(as_n_raw, as_min, as_max)
         as_p = np.clip(as_p_raw, as_min, as_max)
 
-        title_text = f"Diseño a flexión de viga {int(b)}x{int(h)}"
+        title_text = f"DISEÑO A FLEXIÓN DE VIGA {int(b)}x{int(h)}"
 
         data_section = [
             ["b (cm)", f"{b}"],
@@ -629,24 +629,24 @@ class DesignWindow(QMainWindow):
         ]
 
         calc_sections = [
-            ("Cálculo del peralte efectivo", [
-                "d = h - r - ϕ estribo - 1/2 ϕ barra",
-                f"d = {h} - {r} - {de} - 1/2 * {db}",
+            ("Peralte: d", [
+                "d = h - ϕ estribo - r - 1/2 ϕ barra",
+                f"d = {h} - {de} - {r} - 1/2 * {db}",
                 f"d = {d:.2f} cm",
             ]),
-            ("Coeficiente β1", [
+            ("Coeficiente B1", [
                 "β1 = 0.85" if fc <= 280 else f"β1 = 0.85 - 0.05*(({fc}-280)/70) = {beta1:.3f}",
             ]),
-            ("As_min", [
+            ("As mín", [
                 "As_min = 0.7 * sqrt(fc)/fy * b * d",
                 f"As_min = 0.7 * sqrt({fc})/{fy} * {b} * {d:.2f}",
                 f"As_min = {as_min:.2f} cm²",
             ]),
-            ("As_max", [
+            ("As máx", [
                 "As_max = 0.75*(0.85 fc β1 / fy)*(6000/(6000+fy))*b*d",
                 f"As_max = {as_max:.2f} cm²",
             ]),
-            ("Fórmula general para As", [
+            ("Fórmula general del As", [
                 "As = (1.7 fc b d)/(2 fy) - 1/2 sqrt((2.89 (fc b d)^2)/fy^2 - (6.8 fc b Mu)/(φ fy^2))",
             ]),
         ]
@@ -695,12 +695,19 @@ class DesignWindow(QMainWindow):
         except Exception:
             pass
 
+        from ..models.utils import draw_beam_section_png
+        import tempfile
+        tmp = tempfile.NamedTemporaryFile(prefix="section_pdf_", suffix=".png", delete=False)
+        tmp.close()
+        section_img = draw_beam_section_png(b, h, r, de, db, tmp.name)
+
         title = title_text
         data = {
             "data_section": data_section,
             "calc_sections": calc_sections,
             "results": result_section,
             "images": images,
+            "section_img": section_img,
         }
         return title, data
 

--- a/src/vigapp/ui/memoria_window.py
+++ b/src/vigapp/ui/memoria_window.py
@@ -77,17 +77,22 @@ class MemoriaWindow(QMainWindow):
         calc_sections = self.data.get("calc_sections", [])
         results = self.data.get("results", [])
         images = self.data.get("images", [])
+        section_img = self.data.get("section_img")
 
-        html = [f"<h1>{self.windowTitle()}</h1>"]
+        html = [f"<h1 style='text-align:center'>{self.windowTitle()}</h1>"]
         if data_section:
-            html.append("<h2>Datos del proyecto</h2>")
-            html.append("<table border='1' cellspacing='0' cellpadding='4'>")
+            html.append("<h2>DATOS</h2>")
+            html.append("<div style='display:flex;align-items:flex-start'>")
+            html.append("<table border='1' cellspacing='0' cellpadding='4' style='flex:1'>")
             for k, v in data_section:
                 html.append(f"<tr><td><b>{k}</b></td><td>{v}</td></tr>")
             html.append("</table>")
+            if section_img:
+                html.append(f"<div style='flex:1;text-align:center'><img src='file://{section_img}' style='max-width:100%;'/></div>")
+            html.append("</div>")
 
         if calc_sections:
-            html.append("<h2>Cálculos</h2>")
+            html.append("<h2>CÁLCULOS</h2>")
             for subtitle, steps in calc_sections:
                 html.append(f"<h3>{subtitle}</h3>")
                 for step in steps:
@@ -145,6 +150,7 @@ class MemoriaWindow(QMainWindow):
             self.data.get("results", []),
             path,
             images=self.data.get("images", []),
+            section_img=self.data.get("section_img"),
         )
 
     def edit_title(self):


### PR DESCRIPTION
## Summary
- display beam section diagram in PDF report and preview
- support formula images in PDF
- reorganize calculation sections and headings
- generate section image when building memory data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_68503590eca8832b84eb3694a3a7001b