### PR TITLE
Center section graphic

### DIFF
--- a/src/vigapp/pdf_report.py
+++ b/src/vigapp/pdf_report.py
@@ -57,7 +57,7 @@ def generate_memoria_pdf(title, data_section, calc_sections, result_section, pat
     images : list[str] | None
         Rutas de imágenes (fórmulas o capturas) a insertar en el reporte.
     section_img : str | None
-        Ruta de la imagen de la sección a mostrar junto a la tabla de datos.
+        Ruta de la imagen de la sección a mostrar en el encabezado del reporte.
     """
     styles = getSampleStyleSheet()
     styles.add(ParagraphStyle(name="Titulo", fontName="Arial-Bold", fontSize=12, alignment=1))
@@ -69,6 +69,16 @@ def generate_memoria_pdf(title, data_section, calc_sections, result_section, pat
                             topMargin=40, bottomMargin=40)
 
     story = [Paragraph(title, styles["Titulo"]), Spacer(1, 12)]
+    if section_img:
+        img = Image(section_img)
+        img.hAlign = "CENTER"
+        max_w = doc.width * 0.6
+        if img.drawWidth > max_w:
+            scale = max_w / img.drawWidth
+            img.drawWidth *= scale
+            img.drawHeight *= scale
+        story.append(img)
+        story.append(Spacer(1, 12))
 
     if data_section:
         story.append(Paragraph("DATOS", styles["Seccion"]))
@@ -79,21 +89,7 @@ def generate_memoria_pdf(title, data_section, calc_sections, result_section, pat
             ("FONTNAME", (0, 0), (-1, -1), "Arial"),
             ("FONTSIZE", (0, 0), (-1, -1), 11),
         ]))
-        elems = [table]
-        if section_img:
-            img = Image(section_img)
-            img.hAlign = "CENTER"
-            max_w = doc.width * 0.45
-            if img.drawWidth > max_w:
-                scale = max_w / img.drawWidth
-                img.drawWidth *= scale
-                img.drawHeight *= scale
-            elems.append(img)
-            data_table = Table([[elems[0], elems[1]]], colWidths=[doc.width*0.55, doc.width*0.45])
-            data_table.setStyle(TableStyle([("VALIGN", (0,0), (-1,-1), "TOP")]))
-            story.append(data_table)
-        else:
-            story.append(table)
+        story.append(table)
         story.append(Spacer(1, 12))
 
     if calc_sections:

--- a/src/vigapp/ui/memoria_window.py
+++ b/src/vigapp/ui/memoria_window.py
@@ -80,16 +80,14 @@ class MemoriaWindow(QMainWindow):
         section_img = self.data.get("section_img")
 
         html = [f"<h1 style='text-align:center'>{self.windowTitle()}</h1>"]
+        if section_img:
+            html.append(f"<p style='text-align:center'><img src='file://{section_img}' style='max-width:60%;'/></p>")
         if data_section:
             html.append("<h2>DATOS</h2>")
-            html.append("<div style='display:flex;align-items:flex-start'>")
-            html.append("<table border='1' cellspacing='0' cellpadding='4' style='flex:1'>")
+            html.append("<table border='1' cellspacing='0' cellpadding='4' style='width:100%'>")
             for k, v in data_section:
                 html.append(f"<tr><td><b>{k}</b></td><td>{v}</td></tr>")
             html.append("</table>")
-            if section_img:
-                html.append(f"<div style='flex:1;text-align:center'><img src='file://{section_img}' style='max-width:100%;'/></div>")
-            html.append("</div>")
 
         if calc_sections:
             html.append("<h2>CÁLCULOS</h2>")


### PR DESCRIPTION
## Summary
- center the section image underneath the title in PDF reports and previews
- remove side-by-side layout with the data table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b94ea524832bb38b87abf60dc711