### PR TITLE
Refactor PDF report generation using LaTeX

### DIFF
--- a/pdf_engine/__init__.py
+++ b/pdf_engine/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility wrapper exposing ``src.pdf_engine`` as top-level package."""
+from importlib import import_module
+_module = import_module("src.pdf_engine")
+
+globals().update(_module.__dict__)
+__all__ = getattr(_module, "__all__", [k for k in globals() if not k.startswith("_")])
+__path__ = _module.__path__

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pylatex
 Pillow
 reportlab
 sympy
+Jinja2

--- a/src/pdf_engine/__init__.py
+++ b/src/pdf_engine/__init__.py
@@ -1,0 +1,3 @@
+"""PDF report generation utilities."""
+from .latex_renderer import render_report
+__all__ = ["render_report"]

--- a/src/pdf_engine/latex_renderer.py
+++ b/src/pdf_engine/latex_renderer.py
@@ -1,0 +1,58 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Any, Dict
+
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATE_NAME = "reporte_flexion.tex"
+
+
+def render_report(title: str, data: Dict[str, Any], output_path: str = "reporte_dise\xf1o_flexion.pdf") -> str:
+    """Render a LaTeX template and compile it to a PDF.
+
+    Parameters
+    ----------
+    title: str
+        Document title.
+    data: dict
+        Dictionary with keys like ``data_section`` or ``calc_sections``.
+    output_path: str
+        Destination path for the generated PDF.
+
+    Returns
+    -------
+    str
+        Path to the generated PDF file.
+    """
+    env = Environment(
+        loader=FileSystemLoader(os.path.join(os.path.dirname(__file__), "templates")),
+        autoescape=False,
+    )
+    template = env.get_template(TEMPLATE_NAME)
+    context = dict(data)
+    context.setdefault("formula_images", [])
+    context["title"] = title.upper()
+    tex_source = template.render(context)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tex_file = os.path.join(tmpdir, "report.tex")
+        with open(tex_file, "w", encoding="utf-8") as fh:
+            fh.write(tex_source)
+
+        try:
+            subprocess.run(
+                ["pdflatex", "-interaction=nonstopmode", tex_file],
+                cwd=tmpdir,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except Exception as exc:  # pragma: no cover - pdflatex might not be present during tests
+            raise RuntimeError("pdflatex execution failed") from exc
+
+        pdf_src = os.path.join(tmpdir, "report.pdf")
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        shutil.move(pdf_src, output_path)
+    return output_path

--- a/src/pdf_engine/templates/reporte_flexion.tex
+++ b/src/pdf_engine/templates/reporte_flexion.tex
@@ -1,0 +1,73 @@
+\documentclass[letterpaper]{article}
+\usepackage[utf8]{inputenc}
+\usepackage{geometry}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{amsmath}
+\geometry{margin=2cm}
+
+\begin{document}
+
+\begin{center}
+{\LARGE \textbf{{{ title }}}}
+\end{center}
+
+{% if section_img %}
+\begin{center}
+\includegraphics[width=0.6\linewidth]{ {{ section_img }} }
+\end{center}
+{% endif %}
+
+{% if data_section %}
+\section*{DATOS}
+\begin{tabular}{@{}ll@{}}
+\toprule
+{% for label, value in data_section %}
+{{ label }} & {{ value }} \\
+{% endfor %}
+\bottomrule
+\end{tabular}
+{% endif %}
+
+{% if calc_sections %}
+\section*{C\'ALCULOS}
+{% for subtitle, steps in calc_sections %}
+\subsection*{{ subtitle }}
+{% for step in steps %}
+{% if step.startswith('$') and step.endswith('$') %}
+\[
+{{ step[1:-1] }}
+\]
+{% else %}
+{{ step }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+{% if results %}
+\section*{RESULTADOS}
+\begin{tabular}{@{}ll@{}}
+\toprule
+{% for label, value in results %}
+{{ label }} & {{ value }} \\
+{% endfor %}
+\bottomrule
+\end{tabular}
+{% endif %}
+
+{% for img in images %}
+\begin{center}
+\includegraphics[width=0.9\linewidth]{ {{ img }} }
+\end{center}
+{% endfor %}
+
+{% if formula_images %}
+{% for fig in formula_images %}
+\begin{center}
+\includegraphics[width=0.8\linewidth]{ {{ fig }} }
+\end{center}
+{% endfor %}
+{% endif %}
+
+\end{document}

--- a/src/vigapp/ui/memoria_window.py
+++ b/src/vigapp/ui/memoria_window.py
@@ -14,7 +14,7 @@ from PyQt5.QtWidgets import (
 )
 import re
 
-from ..pdf_report import generate_memoria_pdf
+from pdf_engine.latex_renderer import render_report
 from ..models.utils import formula_html
 
 
@@ -141,15 +141,35 @@ class MemoriaWindow(QMainWindow):
 
     def _generate(self, path: str):
         """Internal helper that builds the PDF using stored data."""
-        generate_memoria_pdf(
-            self.windowTitle(),
-            self.data.get("data_section", []),
-            self.data.get("calc_sections", []),
-            self.data.get("results", []),
-            path,
-            images=self.data.get("images", []),
-            section_img=self.data.get("section_img"),
-        )
+        data = {
+            "data_section": self.data.get("data_section", []),
+            "calc_sections": self.data.get("calc_sections", []),
+            "results": self.data.get("results", []),
+            "images": self.data.get("images", []),
+            "section_img": self.data.get("section_img"),
+            "formula_images": [
+                os.path.join(
+                    os.path.dirname(__file__),
+                    "..",
+                    "..",
+                    "resources",
+                    "flexion",
+                    "figures",
+                    "peralte.png",
+                ),
+                os.path.join(
+                    os.path.dirname(__file__),
+                    "..",
+                    "..",
+                    "resources",
+                    "flexion",
+                    "figures",
+                    "pb.png",
+                ),
+            ],
+        }
+
+        render_report(self.windowTitle(), data, path)
 
     def edit_title(self):
         """Allow user to manually edit the window and header title."""


### PR DESCRIPTION
## Summary
- implement new LaTeX based renderer `pdf_engine` with Jinja2
- create default template for flexion reports
- add wrapper package for easier imports
- switch `MemoriaWindow` to new `render_report` function
- require `Jinja2`
- include placeholder resources directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850dcb58e10832bbf3813e2c9787cac