### PR TITLE
Improve pdflatex error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Esta aplicación implementa una interfaz gráfica para el cálculo y diseño de 
 
 Para más detalles de configuración revisa [DESARROLLO.md](DESARROLLO.md).
 
+## Requisitos adicionales
+
+Para generar los reportes en PDF se necesita tener instalada una distribución de
+LaTeX que provea el ejecutable `pdflatex`. En Windows se recomienda instalar
+[MiKTeX](https://miktex.org/) y asegurarse de que `pdflatex` esté disponible en
+la variable de entorno `PATH`.
+
 # Alcance:
 
 INSTRUCCIÓN PARA GENERAR UNA APLICACIÓN EN PYTHON – DISEÑO DE VIGAS SEGÚN NTP E.060 (PERÚ)

--- a/src/pdf_engine/latex_renderer.py
+++ b/src/pdf_engine/latex_renderer.py
@@ -99,8 +99,14 @@ def render_report(title: str, data: Dict[str, Any], output_path: str = "reporte_
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-        except Exception as exc:  # pragma: no cover - pdflatex might not be present during tests
-            raise RuntimeError("pdflatex execution failed") from exc
+        except FileNotFoundError as exc:  # pragma: no cover - pdflatex not installed
+            raise RuntimeError(
+                "pdflatex executable not found. Please ensure LaTeX is installed and in PATH."
+            ) from exc
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - LaTeX error
+            output = (exc.stdout or b"") + (exc.stderr or b"")
+            output = output.decode(errors="ignore")
+            raise RuntimeError(f"pdflatex execution failed:\n{output}") from exc
 
         pdf_src = os.path.join(tmpdir, "report.pdf")
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)


### PR DESCRIPTION
## Summary
- show clearer message when `pdflatex` is missing or fails
- document LaTeX requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f3e8f0ac832bbe031f0465c78f5d