### PR TITLE
Automate section capture for PDF report

### DIFF
--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -589,6 +589,8 @@ class DesignWindow(QMainWindow):
         if title is None or data is None:
             return
         self.mem_win = MemoriaWindow(title, data)
+        # Provide section widget so the PDF can embed its snapshot
+        self.mem_win.widget_seccion = self.canvas_sec
         self.mem_win.show()
 
     def _build_memoria(self):

--- a/src/vigapp/ui/menu_window.py
+++ b/src/vigapp/ui/menu_window.py
@@ -324,10 +324,13 @@ class MenuWindow(QMainWindow):
                 show_window=False,
                 menu_callback=self.show_menu,
             )
+            # Attach section widget for automatic capture on export
+            self.mem_page.widget_seccion = self.design_page.canvas_sec
             self.stacked.addWidget(self.mem_page)
         else:
             self.mem_page.setWindowTitle(title)
             self.mem_page.set_data(data)
+            self.mem_page.widget_seccion = self.design_page.canvas_sec
         self.stacked.setCurrentWidget(self.mem_page)
 
     def show_design(self):


### PR DESCRIPTION
## Summary
- attach the design cross-section widget to `MemoriaWindow` so the PDF exporter can grab it
- provide the widget from both design and menu windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521d16ca28832bbf7367acdab732cc