### PR TITLE
Fix LaTeX report data

### DIFF
--- a/src/pdf_engine/latex_renderer.py
+++ b/src/pdf_engine/latex_renderer.py
@@ -64,11 +64,11 @@ def render_report(title: str, data: Dict[str, Any], output_path: str = "reporte_
             context[key] = _format_num(val, unit, mpa=is_fc)
 
     if "d" in context:
-        context["d"] = _format_num(context["d"], "cm", False)
+        context["d"] = _format_num(context["d"], "cm", mpa=False)
 
     for a_key in ("as_min", "as_max"):
         if a_key in context:
-            context[a_key] = _format_num(context[a_key], "cm²", False)
+            context[a_key] = _format_num(context[a_key], "cm²", mpa=False)
 
     def _replace_units(text: str) -> str:
         return (text.replace("MPa", "kgf/cm²")

--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -722,6 +722,20 @@ class DesignWindow(QMainWindow):
             "results": result_section,
             "images": images,
             "section_img": section_img,
+            # Valores clave para el reporte LaTeX
+            "d": d,
+            "b1": beta1,
+            "pbal": p_bal,
+            "pmax": p_max,
+            "as_min": as_min,
+            "as_max": as_max,
+            # Fórmulas principales en formato LaTeX
+            "formula_peralte": calc_sections[0][1][0].strip("$"),
+            "formula_b1": calc_sections[1][1][0].strip("$"),
+            "formula_pbal": calc_sections[2][1][0].strip("$"),
+            "formula_pmax": calc_sections[3][1][0].strip("$"),
+            "formula_asmin": calc_sections[4][1][0].strip("$"),
+            "formula_asmax": calc_sections[5][1][0].strip("$"),
         }
         return title, data
 


### PR DESCRIPTION
## Summary
- include key calculation values and formulas in the data used for PDF reports
- fix arguments to `_format_num` so keyword parameter is respected

## Testing
- `PYTHONPATH=./src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853898d5ca4832ba7d154baadd10a7e