### PR TITLE
Fix template syntax and add pdf_engine wrapper

### DIFF
--- a/pdf_engine/__init__.py
+++ b/pdf_engine/__init__.py
@@ -1,0 +1,12 @@
+"""Compatibility wrapper exposing the ``src.pdf_engine`` package as ``pdf_engine``."""
+
+from importlib import import_module
+
+_module = import_module("src.pdf_engine")
+
+globals().update(_module.__dict__)
+
+__all__ = getattr(_module, "__all__", [k for k in globals() if not k.startswith("_")])
+
+# Ensure submodules can be imported from this package
+__path__ = _module.__path__

--- a/src/pdf_engine/templates/reporte_flexion.tex
+++ b/src/pdf_engine/templates/reporte_flexion.tex
@@ -40,7 +40,7 @@ fy & {{ fy|default('')|escape }} \\
 \vspace{0.5cm}
 
 {% for subtitle, steps in calc_sections %}
-\section*{{{ '{' }}}{{ subtitle }}{{ '}' }}}
+\section*{ {{ subtitle }} }
 {% for step in steps %}
 \[
 {{ step.strip('$') }}


### PR DESCRIPTION
## Summary
- fix LaTeX template section header for jinja2
- add compatibility wrapper so `pdf_engine` can be imported from project root

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538e0ab2e0832b83d425d595a865be