### PR TITLE
Improve error handling for LaTeX generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ LaTeX que provea el ejecutable `pdflatex`. En Windows se recomienda instalar
 [MiKTeX](https://miktex.org/) y asegurarse de que `pdflatex` esté disponible en
 la variable de entorno `PATH`.
 
+Si la compilación falla y MiKTeX informa que la base de datos está dañada o que
+no se han verificado las actualizaciones, abre **MiKTeX Console** y ejecuta una
+actualización completa. Luego puedes reparar la base de datos con:
+
+```bash
+initexmf --update-fndb
+```
+
 # Alcance:
 
 INSTRUCCIÓN PARA GENERAR UNA APLICACIÓN EN PYTHON – DISEÑO DE VIGAS SEGÚN NTP E.060 (PERÚ)


### PR DESCRIPTION
## Summary
- capture `pdflatex` stderr/stdout and store in `pdflatex_error.log`
- raise clearer exceptions when PDF generation fails
- add troubleshooting note about MiKTeX updates in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685391af4b00832bb3f13f098a71a73e