### PR TITLE
Add polished HTML report with auto-open

### DIFF
--- a/reporte_flexion_html.py
+++ b/reporte_flexion_html.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import webbrowser
 from typing import Dict, Any
 
 def generar_reporte_html(datos: Dict[str, Any], resultados: Dict[str, Dict[str, Any]]) -> None:
@@ -10,11 +12,21 @@ def generar_reporte_html(datos: Dict[str, Any], resultados: Dict[str, Dict[str, 
 
     html = [
         "<!DOCTYPE html>",
-        "<html><head>",
+        "<html>",
+        "<head>",
         "<meta charset='utf-8'>",
+        "<title>Diseño a Flexión de Viga</title>",
         "<script src='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'></script>",
-        "<style>body{font-family:Arial,sans-serif;margin:20px;}h1{text-align:center;}table{border-collapse:collapse;margin:auto;}td,th{border:1px solid #000;padding:4px;}h2{margin-top:1.2em;}</style>",
-        "</head><body>",
+        "<style>",
+        "body{font-family:Arial,sans-serif;background:#fff;margin:20px auto;max-width:800px;}",
+        "h1,h2,h3{text-align:center;}",
+        "table{border-collapse:collapse;margin:auto;width:100%;}",
+        "td,th{border:1px solid #000;padding:4px;}",
+        "button{display:block;margin:20px auto;}",
+        "img{display:block;margin:auto;max-width:90%;}",
+        "</style>",
+        "</head>",
+        "<body>",
         f"<h1>{titulo}</h1>",
         "<h2>DATOS</h2>",
         "<table>"
@@ -37,13 +49,20 @@ def generar_reporte_html(datos: Dict[str, Any], resultados: Dict[str, Dict[str, 
         valor = info.get("valor", "")
         html.append(f"<h2>{titulo_sec}</h2>")
         if formula:
-            html.append(f"<p>$$ {formula} $$</p>")
+            html.append(f"<div>$$ {formula} $$</div>")
         if valor != "":
-            html.append(f"<p><b>Resultado:</b> {valor}</p>")
+            html.append(f"<div><b>Resultado:</b> {valor}</div>")
 
+    html.append("<button onclick=\"window.print()\">Exportar a PDF</button>")
     html.append("</body></html>")
 
     path = os.path.join("html_report", "reporte_flexion.html")
     with open(path, "w", encoding="utf-8") as fh:
         fh.write("\n".join(html))
     print(f"Reporte guardado en {path}")
+
+    abs_path = os.path.abspath(path)
+    try:
+        subprocess.run(["start", "chrome", abs_path], shell=True)
+    except Exception:
+        webbrowser.open(f"file://{abs_path}")


### PR DESCRIPTION
## Summary
- improve HTML template for flexion design report
- support export to PDF via `window.print()` button
- open generated report automatically in Chrome or a default browser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f9c61c10832b9653e24944c6daea