### PR TITLE
Improve report visuals

### DIFF
--- a/src/vigapp/ui/design_window.py
+++ b/src/vigapp/ui/design_window.py
@@ -658,7 +658,10 @@ class DesignWindow(QMainWindow):
                 "resultado": forms[2] if len(forms) > 2 else "",
             }
         tabla = data.get("verif_table", [])
-        generar_reporte_html(datos, resultados, tabla)
+        imagenes = data.get("images", [])
+        seccion = data.get("section_img")
+        dev_as = calc_sections[6:]
+        generar_reporte_html(datos, resultados, tabla, imagenes, seccion, dev_as)
 
     def _build_memoria(self):
         """Return title and structured data for the calculation memory."""

--- a/src/vigapp/ui/menu_window.py
+++ b/src/vigapp/ui/menu_window.py
@@ -325,7 +325,10 @@ class MenuWindow(QMainWindow):
                 "resultado": forms[2] if len(forms) > 2 else "",
             }
         tabla = data.get("verif_table", [])
-        generar_reporte_html(datos, resultados, tabla)
+        imagenes = data.get("images", [])
+        seccion = data.get("section_img")
+        dev_as = calc_sections[6:]
+        generar_reporte_html(datos, resultados, tabla, imagenes, seccion, dev_as)
 
     def show_design(self):
         if hasattr(self, "design_page"):


### PR DESCRIPTION
## Summary
- extend `generar_reporte_html` to include page breaks, editable fields and images
- pass new parameters from `DesignWindow` and `MenuWindow`
- keep tests green

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856085a9598832bade61a8cc777f8bf