### PR TITLE
Fix legend visibility in View3D

### DIFF
--- a/src/vigapp/ui/view3d_window.py
+++ b/src/vigapp/ui/view3d_window.py
@@ -74,7 +74,8 @@ class View3DWindow(QMainWindow):
 
         layout.addStretch()
 
-        self.fig = plt.figure(figsize=(8, 3), constrained_layout=True)
+        # Slightly taller figure so the diameter legend fits comfortably
+        self.fig = plt.figure(figsize=(8, 4), constrained_layout=True)
         self.ax_sections = [self.fig.add_subplot(1, 3, i + 1) for i in range(3)]
         self.canvas = FigureCanvas(self.fig)
         layout.addWidget(self.canvas, alignment=Qt.AlignCenter)


### PR DESCRIPTION
## Summary
- raise the matplotlib figure height in `view3d_window.py` so the diameter legend is visible

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858909b37d0832b8adbc6aaf61cfe99