### PR TITLE
Fix legend display in View3D

### DIFF
--- a/src/vigapp/ui/view3d_window.py
+++ b/src/vigapp/ui/view3d_window.py
@@ -155,9 +155,8 @@ class View3DWindow(QMainWindow):
                 handles=handles,
                 title="Di\u00e1metros",
                 loc="lower center",
-                bbox_to_anchor=(0.5, -0.08),
+                bbox_to_anchor=(0.5, 0.05),
                 ncol=len(handles),
-                
             )
 
         self.canvas.draw()


### PR DESCRIPTION
## Summary
- tweak legend anchor so it stays visible in the section view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685899009ec4832bbc318feec1b16c4e