### PR TITLE
Adjust report headings and add CAD export option

### DIFF
--- a/html_report/reporte_flexion.html
+++ b/html_report/reporte_flexion.html
@@ -51,12 +51,12 @@ function exportWord(){var html=document.documentElement.outerHTML;var blob=new B
 <img src='img_seccion_viga.png' class='imagen-centro' alt='Sección'>
 </div>
 </div>
-<h2>CALCULOS</h2>
-<h3 id='h1' contenteditable='false'>Cálculo de Peralte <span class='norma'>(E060 Art. 17.5.2)</span> <button onclick="toggleEdit(this,'h1')">Editar</button></h3>
+<h2>CALUCLOS</h2>
+<h3 id='h1' contenteditable='false'>Cal. de Peralte <span class='norma'>(E060 Art. 17.5.2)</span> <button onclick="toggleEdit(this,'h1')">Editar</button></h3>
 <div id='f1' class='formula' contenteditable='false'>$$ d = h - d_e - \frac{1}{2} d_b - r $$ <button onclick="toggleEdit(this,'f1')">Editar</button></div>
 <div id='r1' class='reemplazo' contenteditable='false'>$$ d = 50.0 - 0.95 - \frac{1}{2} 1.59 - 4.0 $$ <button onclick="toggleEdit(this,'r1')">Editar</button></div>
 <div id='s1' class='resultado' contenteditable='false'>$$ d = 44.25\,\text{cm} $$ <button onclick="toggleEdit(this,'s1')">Editar</button></div>
-<h3 id='h2' contenteditable='false'>Cálculo de B1 <span class='norma'>(E060 Art. 10.2.7.3)</span> <button onclick="toggleEdit(this,'h2')">Editar</button></h3>
+<h3 id='h2' contenteditable='false'>Cal. de ß1 <span class='norma'>(E060 Art. 10.2.7.3)</span> <button onclick="toggleEdit(this,'h2')">Editar</button></h3>
 <div id='f2' class='formula' contenteditable='false'>$$ \beta_1 = 0.85 $$ <button onclick="toggleEdit(this,'f2')">Editar</button></div>
 <h3 id='h3' contenteditable='false'>Cρ<sub>bal</sub> <span class='norma'>(E060 Art. 10.3.32)</span> <button onclick="toggleEdit(this,'h3')">Editar</button></h3>
 <div id='f3' class='formula' contenteditable='false'>$$ \rho_{bal}=\left(\frac{0.85 f_c \beta_1}{f_y}\right)\,\frac{6000}{6000+f_y} $$ <button onclick="toggleEdit(this,'f3')">Editar</button></div>
@@ -66,11 +66,11 @@ function exportWord(){var html=document.documentElement.outerHTML;var blob=new B
 <div id='f4' class='formula' contenteditable='false'>$$ \rho_{max}=0.75\,\rho_{bal} $$ <button onclick="toggleEdit(this,'f4')">Editar</button></div>
 <div id='r4' class='reemplazo' contenteditable='false'>$$ \rho_{max}=0.75\times0.0212 $$ <button onclick="toggleEdit(this,'r4')">Editar</button></div>
 <div id='s4' class='resultado' contenteditable='false'>$$ \rho_{max} = 0.0159 $$ <button onclick="toggleEdit(this,'s4')">Editar</button></div>
-<h3 id='h5' contenteditable='false'>Cálculo de As mín <span class='norma'>(E060 Art. 10.5.2)</span> <button onclick="toggleEdit(this,'h5')">Editar</button></h3>
+<h3 id='h5' contenteditable='false'>Cal. de As mín <span class='norma'>(E060 Art. 10.5.2)</span> <button onclick="toggleEdit(this,'h5')">Editar</button></h3>
 <div id='f5' class='formula' contenteditable='false'>$$ A_s^{\text{min}} = 0.7\,\frac{\sqrt{f_c}}{f_y}\, b\, d $$ <button onclick="toggleEdit(this,'f5')">Editar</button></div>
 <div id='r5' class='reemplazo' contenteditable='false'>$$ A_s^{\text{min}} = 0.7\,\frac{\sqrt{210.0}}{4200.0}\,30.0\,44.25 $$ <button onclick="toggleEdit(this,'r5')">Editar</button></div>
 <div id='s5' class='resultado' contenteditable='false'>$$ A_s^{\text{min}} = 3.21\,\text{cm}^2 $$ <button onclick="toggleEdit(this,'s5')">Editar</button></div>
-<h3 id='h6' contenteditable='false'>Cálculo de As máx <span class='norma'>(E060 Art. 10.3.4)</span> <button onclick="toggleEdit(this,'h6')">Editar</button></h3>
+<h3 id='h6' contenteditable='false'>Cal. de As máx <span class='norma'>(E060 Art. 10.3.4)</span> <button onclick="toggleEdit(this,'h6')">Editar</button></h3>
 <div id='f6' class='formula' contenteditable='false'>$$ A_s^{\text{max}} = 0.75\,\left(\frac{0.85 f_c \beta_1}{f_y}\right)\,\left(\frac{6000}{6000+f_y}\right)\,b\,d $$ <button onclick="toggleEdit(this,'f6')">Editar</button></div>
 <div id='r6' class='reemplazo' contenteditable='false'>$$ A_s^{\text{max}} = 21.16\,\text{cm}^2 $$ <button onclick="toggleEdit(this,'r6')">Editar</button></div>
 <h2>DESARROLLO AS REQUERIDO</h2>

--- a/reporte_flexion_html.py
+++ b/reporte_flexion_html.py
@@ -85,15 +85,15 @@ def generar_reporte_html(
     )
 
     orden = [
-        ("C\u00e1lculo de Peralte <span class='norma'>(E060 Art. 17.5.2)</span>", "peralte"),
-        ("C\u00e1lculo de B1 <span class='norma'>(E060 Art. 10.2.7.3)</span>", "b1"),
+        ("Cal. de Peralte <span class='norma'>(E060 Art. 17.5.2)</span>", "peralte"),
+        ("Cal. de \u00df1 <span class='norma'>(E060 Art. 10.2.7.3)</span>", "b1"),
         ("C\u03c1<sub>bal</sub> <span class='norma'>(E060 Art. 10.3.32)</span>", "pbal"),
         ("C\u03c1<sub>max</sub> <span class='norma'>(E060 Art. 10.3.4)</span>", "pmax"),
-        ("C\u00e1lculo de As m\u00edn <span class='norma'>(E060 Art. 10.5.2)</span>", "as_min"),
-        ("C\u00e1lculo de As m\u00e1x <span class='norma'>(E060 Art. 10.3.4)</span>", "as_max"),
+        ("Cal. de As m\u00edn <span class='norma'>(E060 Art. 10.5.2)</span>", "as_min"),
+        ("Cal. de As m\u00e1x <span class='norma'>(E060 Art. 10.3.4)</span>", "as_max"),
     ]
 
-    html.append("<h2>CALCULOS</h2>")
+    html.append("<h2>CALUCLOS</h2>")
     sec_id = 0
     for subt, key in orden:
         info = resultados.get(key, {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sympy
 python-docx
 reportlab
 Jinja2
+ezdxf

--- a/src/vigapp/ui/view3d_window.py
+++ b/src/vigapp/ui/view3d_window.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import (
     QApplication,
     QLineEdit,
     QLabel,
+    QMessageBox,
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QGuiApplication
@@ -87,11 +88,17 @@ class View3DWindow(QMainWindow):
         btn_layout = QHBoxLayout()
         self.btn_capture = QPushButton("CAPTURA")
         self.btn_capture.clicked.connect(self._capture_view)
+        self.btn_update = QPushButton("ACTUALIZAR")
+        self.btn_update.clicked.connect(self.draw_views)
+        self.btn_export = QPushButton("EXPORTAR CAD")
+        self.btn_export.clicked.connect(self.export_cad)
         self.btn_back = QPushButton("RETROCEDER")
         self.btn_back.clicked.connect(self.on_back)
         self.btn_menu = QPushButton("MENÚ")
         self.btn_menu.clicked.connect(self.on_menu)
         btn_layout.addWidget(self.btn_capture)
+        btn_layout.addWidget(self.btn_update)
+        btn_layout.addWidget(self.btn_export)
         btn_layout.addWidget(self.btn_back)
         btn_layout.addWidget(self.btn_menu)
         layout.addLayout(btn_layout)
@@ -453,4 +460,85 @@ class View3DWindow(QMainWindow):
     def on_menu(self):
         if self.menu_callback:
             self.menu_callback()
+
+    def export_cad(self):
+        """Export current sections to a simple DXF file."""
+        try:
+            import ezdxf
+        except Exception:
+            return
+
+        try:
+            b = float(self.design.edits["b (cm)"].text())
+            h = float(self.design.edits["h (cm)"].text())
+            r = float(self.design.edits["r (cm)"].text())
+        except ValueError:
+            return
+
+        de = DIAM_CM.get(self.design.cb_estribo.currentText(), 0)
+
+        doc = ezdxf.new()
+        msp = doc.modelspace()
+
+        for i in range(3):
+            off = i * (b + 20)
+            msp.add_lwpolyline([
+                (off, 0),
+                (off + b, 0),
+                (off + b, h),
+                (off, h),
+                (off, 0),
+            ])
+            msp.add_lwpolyline([
+                (off + r, r),
+                (off + b - r, r),
+                (off + b - r, h - r),
+                (off + r, h - r),
+                (off + r, r),
+            ])
+            msp.add_lwpolyline([
+                (off + r + de, r + de),
+                (off + b - r - de, r + de),
+                (off + b - r - de, h - r - de),
+                (off + r + de, h - r - de),
+                (off + r + de, r + de),
+            ])
+
+            neg_layers = self._collect_bars(i)
+            pos_layers = self._collect_bars(i + 3)
+            pos_y = self._layer_positions_bottom(pos_layers, r, de)
+            neg_y = self._layer_positions_top(neg_layers, r, de, h)
+            pos_counts = [len(pos_layers.get(l, [])) for l in sorted(pos_layers)]
+            neg_counts = [len(neg_layers.get(l, [])) for l in sorted(neg_layers)]
+
+            orders_pos = self.pos_orders[i] if i < len(self.pos_orders) else []
+            orders_neg = self.neg_orders[i] if i < len(self.neg_orders) else []
+
+            start = 0
+            for layer in sorted(pos_layers):
+                bars = orders_pos[start:start + pos_counts.pop(0)] or [key for _, key in pos_layers[layer]]
+                diams = [DIAM_CM.get(k, 0) for k in bars]
+                xs = self._distribute_x(diams, b, r, de)
+                y = pos_y.get(layer, r + de)
+                for x, key in zip(xs, bars):
+                    d = DIAM_CM.get(key, 0) / 2
+                    msp.add_circle((off + x, y), d)
+                start += len(bars)
+
+            start = 0
+            for layer in sorted(neg_layers):
+                bars = orders_neg[start:start + neg_counts.pop(0)] or [key for _, key in neg_layers[layer]]
+                diams = [DIAM_CM.get(k, 0) for k in bars]
+                xs = self._distribute_x(diams, b, r, de)
+                y = neg_y.get(layer, h - (r + de))
+                for x, key in zip(xs, bars):
+                    d = DIAM_CM.get(key, 0) / 2
+                    msp.add_circle((off + x, y), d)
+                start += len(bars)
+
+        try:
+            doc.saveas("secciones.dxf")
+            QMessageBox.information(self, "Exportar CAD", "Archivo secciones.dxf guardado")
+        except Exception:
+            QMessageBox.warning(self, "Exportar CAD", "No se pudo guardar el DXF")
 


### PR DESCRIPTION
## Summary
- tweak HTML report headings (`CALUCLOS`, `Cal. de ß1`, etc.)
- update Python HTML generator with same titles
- add DXF export and update buttons to the section view window
- include `ezdxf` in dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_685962024270832ba7a2243d71bafdfd