### PR TITLE
Refresh section views after design changes

### DIFF
--- a/src/vigapp/ui/menu_window.py
+++ b/src/vigapp/ui/menu_window.py
@@ -303,6 +303,9 @@ class MenuWindow(QMainWindow):
                 back_callback=self.show_design,
             )
             self.stacked.addWidget(self.desarrollo_page)
+        else:
+            # Refresh drawings when returning to the sections page
+            self.desarrollo_page.draw_views(reset_orders=True)
         self.stacked.setCurrentWidget(self.desarrollo_page)
 
     # ------------------------------------------------------------------

--- a/src/vigapp/ui/view3d_window.py
+++ b/src/vigapp/ui/view3d_window.py
@@ -89,7 +89,7 @@ class View3DWindow(QMainWindow):
         self.btn_capture = QPushButton("CAPTURA")
         self.btn_capture.clicked.connect(self._capture_view)
         self.btn_update = QPushButton("ACTUALIZAR")
-        self.btn_update.clicked.connect(self.draw_views)
+        self.btn_update.clicked.connect(lambda: self.draw_views(reset_orders=True))
         self.btn_export = QPushButton("EXPORTAR CAD")
         self.btn_export.clicked.connect(self.export_cad)
         self.btn_back = QPushButton("RETROCEDER")
@@ -120,8 +120,16 @@ class View3DWindow(QMainWindow):
         self.fig.suptitle(text.upper(), fontweight="bold")
         self.canvas.draw_idle()
 
-    def draw_views(self):
-        """Redraw the three section cuts."""
+    def draw_views(self, *, reset_orders: bool = False):
+        """Redraw the three section cuts.
+
+        Parameters
+        ----------
+        reset_orders : bool, optional
+            If ``True`` the stored bar orders are regenerated from the current
+            design inputs. This ensures that changes made in the design window
+            are reflected when returning to this view.
+        """
         try:
             b = float(self.design.edits["b (cm)"].text())
             h = float(self.design.edits["h (cm)"].text())
@@ -136,9 +144,10 @@ class View3DWindow(QMainWindow):
 
         neg_layers = [self._collect_bars(i) for i in range(3)]
         pos_layers = [self._collect_bars(i + 3) for i in range(3)]
-        if not self.neg_orders:
+
+        if reset_orders or not self.neg_orders:
             self.neg_orders = [self._collect_order(i) for i in range(3)]
-        if not self.pos_orders:
+        if reset_orders or not self.pos_orders:
             self.pos_orders = [self._collect_order(i + 3) for i in range(3)]
         titles = ["M1", "M2", "M3"]
 


### PR DESCRIPTION
## Summary
- refresh rebar ordering when returning to the sections view
- allow the "ACTUALIZAR" button to rebuild rebar data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859651bb854832b834a81a6cf8d9994