### PR TITLE
Fix shear design temp path and reorder menu

### DIFF
--- a/src/vigapp/ui/menu_window.py
+++ b/src/vigapp/ui/menu_window.py
@@ -233,8 +233,8 @@ class MenuWindow(QMainWindow):
             btn_layout.addLayout(row)
 
         add_row(btn_flex, "DISE\u00d1O POR FLEXI\u00d3N")
-        add_row(btn_torsion, "DISE\u00d1O POR TORSI\u00d3N")
         add_row(btn_cort, "DISE\u00d1O POR CORTANTE")
+        add_row(btn_torsion, "DISE\u00d1O POR TORSI\u00d3N")
         add_row(btn_mem, "MEMORIA DE C\u00c1LCULO")
         add_row(btn_contact, "CONTACTO")
         btn_layout.addItem(

--- a/src/vigapp/ui/shear_design_window.py
+++ b/src/vigapp/ui/shear_design_window.py
@@ -17,6 +17,7 @@ import matplotlib.pyplot as plt
 
 from ..models.constants import DIAM_CM, BAR_DATA
 from ..models.utils import draw_beam_section_png
+import tempfile
 
 import math
 
@@ -120,7 +121,9 @@ class ShearDesignWindow(QMainWindow):
             db = DIAM_CM.get(self.cb_barra.currentText(), 0)
         except ValueError:
             return
-        path = draw_beam_section_png(b, h, r, de, db, "/tmp/sec.png")
+        tmp = tempfile.NamedTemporaryFile(prefix="sec_", suffix=".png", delete=False)
+        tmp.close()
+        path = draw_beam_section_png(b, h, r, de, db, tmp.name)
         self.ax.clear()
         img = plt.imread(path)
         self.ax.imshow(img)


### PR DESCRIPTION
## Summary
- use a temporary file in the shear design window instead of `/tmp/sec.png`
- reorder the menu so the shear design option appears second

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ffe1cc90832bbfc1815643f3f5d1