### PR TITLE
Switch capture buttons to icons

### DIFF
--- a/vigapp/ui/design_window.py
+++ b/vigapp/ui/design_window.py
@@ -350,6 +350,7 @@ class DesignWindow(QMainWindow):
         )
         self.btn_capture = QPushButton()
         self.btn_capture.setIcon(QIcon(icon_path))
+        self.btn_capture.setFixedWidth(30)
         self.btn_memoria = QPushButton("Reportes")
         self.btn_view3d = QPushButton("Secciones")
         self.btn_menu = QPushButton("Menú")

--- a/vigapp/ui/formula_window.py
+++ b/vigapp/ui/formula_window.py
@@ -14,7 +14,7 @@ from PyQt5.QtWidgets import (
     QFileDialog,
     QComboBox,
 )
-from PyQt5.QtGui import QGuiApplication
+from PyQt5.QtGui import QGuiApplication, QIcon
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt
 import sympy as sp
@@ -77,7 +77,12 @@ class FormulaWindow(QMainWindow):
         layout.addWidget(self.canvas)
 
         btns = QHBoxLayout()
-        self.btn_capture = QPushButton("Capturar")
+        icon_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "icon", "botones", "captura", "capture.png"
+        )
+        self.btn_capture = QPushButton()
+        self.btn_capture.setIcon(QIcon(icon_path))
+        self.btn_capture.setFixedWidth(30)
         self.btn_capture.clicked.connect(self.capture)
         self.btn_export = QPushButton("Exportar…")
         self.btn_export.clicked.connect(self.export)

--- a/vigapp/ui/moment_app.py
+++ b/vigapp/ui/moment_app.py
@@ -12,7 +12,8 @@ from PyQt5.QtWidgets import (
     QMessageBox,
 )
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QGuiApplication
+from PyQt5.QtGui import QGuiApplication, QIcon
+import os
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt
 import numpy as np
@@ -74,7 +75,12 @@ class MomentApp(QMainWindow):
 
         btn_calc = QPushButton("Diagramar")
         btn_next = QPushButton("Diseño")
-        btn_capture = QPushButton("Captura")
+        icon_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "icon", "botones", "captura", "capture.png"
+        )
+        btn_capture = QPushButton()
+        btn_capture.setIcon(QIcon(icon_path))
+        btn_capture.setFixedWidth(30)
         btn_menu = QPushButton("Menú")
 
         btn_calc.clicked.connect(self.on_calculate)

--- a/vigapp/ui/view3d_window.py
+++ b/vigapp/ui/view3d_window.py
@@ -94,6 +94,7 @@ class View3DWindow(QMainWindow):
         )
         self.btn_capture = QPushButton()
         self.btn_capture.setIcon(QIcon(icon_path))
+        self.btn_capture.setFixedWidth(30)
         self.btn_capture.clicked.connect(self._capture_view)
         self.btn_exportar = QPushButton("Exportar CAD")
         self.btn_exportar.clicked.connect(self._on_exportar_cad)


### PR DESCRIPTION
## Summary
- use capture icon instead of text for diagram, formulas, design, and 3D windows
- keep capture behavior but standardize button width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2391e104832b845895a5e116d279