### PR TITLE
Fix pdf_engine import

### DIFF
--- a/pdf_engine/__init__.py
+++ b/pdf_engine/__init__.py
@@ -1,8 +1,8 @@
-"""Compatibility wrapper exposing the ``src.pdf_engine`` package as ``pdf_engine``."""
+"""Compatibility wrapper exposing the ``vigapp.pdf_engine`` package as ``pdf_engine``."""
 
 from importlib import import_module
 
-_module = import_module("src.pdf_engine")
+_module = import_module("vigapp.pdf_engine")
 
 globals().update(_module.__dict__)
 


### PR DESCRIPTION
## Summary
- fix compatibility wrapper to import `vigapp.pdf_engine`

## Testing
- `pip install --quiet -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f32bdc798832b9f7abb1469270a50