### PR TITLE
Add CONTRIBUTING and dev requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contribuir al Proyecto
+
+Este repositorio utiliza **pytest** para las pruebas automatizadas. Para poder ejecutarlas debes contar con las siguientes bibliotecas instaladas:
+
+- PyQt5
+- numpy
+- matplotlib
+- scipy
+- mplcursors
+- pyqtgraph
+- sympy
+- python-docx
+- reportlab
+- Jinja2
+- ezdxf
+- pytest
+
+Puedes instalar todas las dependencias de desarrollo con:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+En entornos sin interfaz gráfica (por ejemplo, servidores de integración continua) establece `QT_QPA_PLATFORM=offscreen` para que Qt no requiera pantalla:
+
+```bash
+QT_QPA_PLATFORM=offscreen pytest
+```
+
+Consulta `DESARROLLO.md` para más detalles de configuración y estilo de código.

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Esta organización modular facilita la comunicación y coordinación dentro del 
 
 ## Guía de desarrollo
 
-Consulta el archivo [DESARROLLO.md](DESARROLLO.md) para pautas sobre configuración del entorno y aportes al código.
+Consulta el archivo [DESARROLLO.md](DESARROLLO.md) para pautas sobre configuración del entorno y aportes al código. Si deseas ejecutar las pruebas automatizadas, revisa también [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Icono de la aplicación
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest


### PR DESCRIPTION
## Summary
- document required packages for tests in a new `CONTRIBUTING.md`
- mention the new guide from the README
- add `requirements-dev.txt` for pytest and runtime dependencies

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f32a5b0bc832baf31f4bd8648e9bd