### PR TITLE
Fix capture icon path for design window

### DIFF
--- a/vigapp/ui/design/widgets.py
+++ b/vigapp/ui/design/widgets.py
@@ -160,7 +160,16 @@ def build_ui(win) -> None:
 
     layout.addLayout(win.combo_grid, row_start + 2, 0, 1, 8)
 
-    icon_path = os.path.join(os.path.dirname(__file__), "..", "..", "icon", "botones", "captura", "capture.png")
+    icon_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "icon",
+        "botones",
+        "captura",
+        "capture.png",
+    )
     win.btn_capture = QPushButton()
     win.btn_capture.setIcon(QIcon(icon_path))
     win.btn_capture.setFixedWidth(30)


### PR DESCRIPTION
## Summary
- fix capture icon path in design widgets so the button shows the same icon as other capture buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703bd599dc832ba085eebe7e7e9073