### PR TITLE
Fix labels in flexion HTML report

### DIFF
--- a/html_report/reporte_flexion.html
+++ b/html_report/reporte_flexion.html
@@ -51,18 +51,18 @@ function exportWord(){var html=document.documentElement.outerHTML;var blob=new B
 <img src="img_seccion_viga.png" style="height:350px; width:auto; object-fit:contain; display:block; margin:auto;" alt="Sección">
 </div>
 </div>
-<h2>CALUCLOS</h2>
+<h2>CÁLCULOS</h2>
 <h3 id='h1' contenteditable='false'>Cal. de Peralte <span class='norma'>(E060 Art. 17.5.2)</span> <button onclick="toggleEdit(this,'h1')">Editar</button></h3>
 <div id='f1' class='formula' contenteditable='false'>$$ d = h - d_e - \frac{1}{2} d_b - r $$ <button onclick="toggleEdit(this,'f1')">Editar</button></div>
 <div id='r1' class='reemplazo' contenteditable='false'>$$ d = 50.0 - 0.95 - \frac{1}{2} 1.59 - 4.0 $$ <button onclick="toggleEdit(this,'r1')">Editar</button></div>
 <div id='s1' class='resultado' contenteditable='false'>$$ d = 44.25\,\text{cm} $$ <button onclick="toggleEdit(this,'s1')">Editar</button></div>
-<h3 id='h2' contenteditable='false'>Cal. de ß1 <span class='norma'>(E060 Art. 10.2.7.3)</span> <button onclick="toggleEdit(this,'h2')">Editar</button></h3>
+<h3 id='h2' contenteditable='false'>Cal. de β1 <span class='norma'>(E060 Art. 10.2.7.3)</span> <button onclick="toggleEdit(this,'h2')">Editar</button></h3>
 <div id='f2' class='formula' contenteditable='false'>$$ \beta_1 = 0.85 $$ <button onclick="toggleEdit(this,'f2')">Editar</button></div>
-<h3 id='h3' contenteditable='false'>Cρ<sub>bal</sub> <span class='norma'>(E060 Art. 10.3.32)</span> <button onclick="toggleEdit(this,'h3')">Editar</button></h3>
+<h3 id='h3' contenteditable='false'>ρ<sub>bal</sub> <span class='norma'>(E060 Art. 10.3.32)</span> <button onclick="toggleEdit(this,'h3')">Editar</button></h3>
 <div id='f3' class='formula' contenteditable='false'>$$ \rho_{bal}=\left(\frac{0.85 f_c \beta_1}{f_y}\right)\,\frac{6000}{6000+f_y} $$ <button onclick="toggleEdit(this,'f3')">Editar</button></div>
 <div id='r3' class='reemplazo' contenteditable='false'>$$ \rho_{bal}=\left(\frac{0.85\,210.0\,0.850}{4200.0}\right)\,\frac{6000}{6000+4200.0} $$ <button onclick="toggleEdit(this,'r3')">Editar</button></div>
 <div id='s3' class='resultado' contenteditable='false'>$$ \rho_{bal} = 0.0212 $$ <button onclick="toggleEdit(this,'s3')">Editar</button></div>
-<h3 id='h4' contenteditable='false'>Cρ<sub>max</sub> <span class='norma'>(E060 Art. 10.3.4)</span> <button onclick="toggleEdit(this,'h4')">Editar</button></h3>
+<h3 id='h4' contenteditable='false'>ρ<sub>max</sub> <span class='norma'>(E060 Art. 10.3.4)</span> <button onclick="toggleEdit(this,'h4')">Editar</button></h3>
 <div id='f4' class='formula' contenteditable='false'>$$ \rho_{max}=0.75\,\rho_{bal} $$ <button onclick="toggleEdit(this,'f4')">Editar</button></div>
 <div id='r4' class='reemplazo' contenteditable='false'>$$ \rho_{max}=0.75\times0.0212 $$ <button onclick="toggleEdit(this,'r4')">Editar</button></div>
 <div id='s4' class='resultado' contenteditable='false'>$$ \rho_{max} = 0.0159 $$ <button onclick="toggleEdit(this,'s4')">Editar</button></div>

--- a/reporte_flexion_html.py
+++ b/reporte_flexion_html.py
@@ -86,14 +86,14 @@ def generar_reporte_html(
 
     orden = [
         ("Cal. de Peralte <span class='norma'>(E060 Art. 17.5.2)</span>", "peralte"),
-        ("Cal. de \u00df1 <span class='norma'>(E060 Art. 10.2.7.3)</span>", "b1"),
-        ("C\u03c1<sub>bal</sub> <span class='norma'>(E060 Art. 10.3.32)</span>", "pbal"),
-        ("C\u03c1<sub>max</sub> <span class='norma'>(E060 Art. 10.3.4)</span>", "pmax"),
+        ("Cal. de β1 <span class='norma'>(E060 Art. 10.2.7.3)</span>", "b1"),
+        ("\u03c1<sub>bal</sub> <span class='norma'>(E060 Art. 10.3.32)</span>", "pbal"),
+        ("\u03c1<sub>max</sub> <span class='norma'>(E060 Art. 10.3.4)</span>", "pmax"),
         ("Cal. de As m\u00edn <span class='norma'>(E060 Art. 10.5.2)</span>", "as_min"),
         ("Cal. de As m\u00e1x <span class='norma'>(E060 Art. 10.3.4)</span>", "as_max"),
     ]
 
-    html.append("<h2>CALUCLOS</h2>")
+    html.append("<h2>C\u00c1LCULOS</h2>")
     sec_id = 0
     for subt, key in orden:
         info = resultados.get(key, {})


### PR DESCRIPTION
## Summary
- update label strings in `reporte_flexion_html.py`
- regenerate `html_report/reporte_flexion.html` with corrected text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5', ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68704154e550832b91ada599ac591978