### PR TITLE
Add shear scheme diagram

### DIFF
--- a/vigapp/graphics/shear_scheme.py
+++ b/vigapp/graphics/shear_scheme.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
+
+
+def _dim_line(ax, x1, x2, y, label, offset=0.15):
+    ax.annotate(
+        "",
+        xy=(x1, y),
+        xytext=(x2, y),
+        arrowprops=dict(arrowstyle="<->", color="black", lw=1),
+        annotation_clip=False,
+    )
+    ax.text((x1 + x2) / 2, y - offset, label, ha="center", va="top", fontsize=9)
+
+
+def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: str = "apoyada") -> None:
+    """Draw a simple shear scheme on ``ax``.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Axis where the diagram is drawn.
+    Vu : float
+        Shear force in ton-force.
+    ln : float
+        Clear span in meters.
+    d : float
+        Effective depth in meters.
+    beam_type : str
+        Either ``"apoyada"`` or ``"volado"``.
+    """
+    ax.clear()
+    h = 0.4
+    support_w = 0.2
+    y0 = 0
+
+    # Beam rectangle
+    if beam_type == "volado":
+        ax.add_patch(Rectangle((0, y0), ln, h, edgecolor="black", facecolor="none"))
+        ax.add_patch(Rectangle((-support_w, y0), support_w, h, facecolor="0.7"))
+        x_vu = ln - d
+        ax.annotate(
+            "",
+            xy=(x_vu, h),
+            xytext=(x_vu, h + 0.3),
+            arrowprops=dict(arrowstyle="-|>", color="red", lw=2),
+        )
+        ax.text(x_vu, h + 0.32, "Vu", color="red", ha="center", va="bottom", fontsize=9)
+        ax.plot([0, ln], [h, 0], color="blue", lw=1)
+        _dim_line(ax, ln, x_vu, y0 - 0.1, "d")
+        _dim_line(ax, 0, ln, y0 - 0.25, f"ln = {ln:.2f} m")
+        ax.set_xlim(-support_w - 0.2, ln + 0.2)
+    else:
+        ax.add_patch(Rectangle((0, y0), ln, h, edgecolor="black", facecolor="none"))
+        x_vu_left = d
+        x_vu_right = ln - d
+        for x_vu in (x_vu_left, x_vu_right):
+            ax.annotate(
+                "",
+                xy=(x_vu, h),
+                xytext=(x_vu, h + 0.3),
+                arrowprops=dict(arrowstyle="-|>", color="red", lw=2),
+            )
+            ax.text(x_vu, h + 0.32, "Vu", color="red", ha="center", va="bottom", fontsize=9)
+        ax.plot([0, ln], [h, 0], color="blue", lw=1)
+        _dim_line(ax, 0, d, y0 - 0.1, "d")
+        _dim_line(ax, ln/2, ln, y0 - 0.1, "ln/2")
+        _dim_line(ax, 0, ln, y0 - 0.25, f"ln = {ln:.2f} m")
+        ax.set_xlim(-0.2, ln + 0.2)
+
+    ax.axis("off")
+    ax.set_ylim(-0.5, h + 0.5)
+

--- a/vigapp/ui/shear_window.py
+++ b/vigapp/ui/shear_window.py
@@ -9,10 +9,13 @@ from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QComboBox,
 )
 from PyQt5.QtCore import Qt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt
+
+from ..graphics.shear_scheme import draw_shear_scheme
 
 
 class ShearDesignWindow(QMainWindow):
@@ -42,6 +45,8 @@ class ShearDesignWindow(QMainWindow):
         self.ed_vu.setAlignment(Qt.AlignRight)
         self.ed_ln = QLineEdit("5.0")
         self.ed_ln.setAlignment(Qt.AlignRight)
+        self.cb_type = QComboBox()
+        self.cb_type.addItems(["Apoyada", "Volado"])
 
         d_val = self.design_win.calc_effective_depth()
         self.ed_d = QLineEdit(f"{d_val:.2f}")
@@ -54,20 +59,23 @@ class ShearDesignWindow(QMainWindow):
         layout.addWidget(self.ed_ln, 1, 1)
         layout.addWidget(QLabel("d (cm)"), 2, 0)
         layout.addWidget(self.ed_d, 2, 1)
+        layout.addWidget(QLabel("Tipo"), 3, 0)
+        layout.addWidget(self.cb_type, 3, 1)
 
         btn_menu = QPushButton("Men\u00fa")
         btn_back = QPushButton("Atr\u00e1s")
-        layout.addWidget(btn_menu, 3, 0)
-        layout.addWidget(btn_back, 3, 1)
+        layout.addWidget(btn_menu, 4, 0)
+        layout.addWidget(btn_back, 4, 1)
 
         self.fig, self.ax = plt.subplots(figsize=(5, 3), constrained_layout=True)
         self.canvas = FigureCanvas(self.fig)
-        layout.addWidget(self.canvas, 4, 0, 1, 2)
+        layout.addWidget(self.canvas, 5, 0, 1, 2)
 
         self.ed_vu.editingFinished.connect(self.draw_diagram)
         self.ed_ln.editingFinished.connect(self.draw_diagram)
         btn_menu.clicked.connect(self.on_menu)
         btn_back.clicked.connect(self.on_back)
+        self.cb_type.currentIndexChanged.connect(self.draw_diagram)
 
         self.draw_diagram()
 
@@ -81,14 +89,9 @@ class ShearDesignWindow(QMainWindow):
             return
 
         d = d_cm / 100.0
-        x = [0, d, L - d, L]
-        y = [0, Vu, Vu, 0]
+        beam_type = "volado" if self.cb_type.currentText().lower() == "volado" else "apoyada"
 
-        self.ax.clear()
-        self.ax.plot(x, y, "b-", lw=2)
-        self.ax.set_xlabel("Longitud (m)")
-        self.ax.set_ylabel("Cortante (T)")
-        self.ax.grid(True)
+        draw_shear_scheme(self.ax, Vu, L, d, beam_type)
         self.canvas.draw()
 
     # ------------------------------------------------------------------
@@ -104,4 +107,5 @@ class ShearDesignWindow(QMainWindow):
             parent = self.parent()
             if parent:
                 parent.show()
+
 


### PR DESCRIPTION
## Summary
- add function to draw shear schemes for simply supported and cantilever beams
- extend shear design window with beam type selector
- use new drawing utility when updating the diagram

## Testing
- `pytest tests/test_shear_window.py::test_shear_diagram_offscreen -vv`
- `pytest tests/test_design_window.py::test_calc_as_req_sample -vv`
- `pytest tests/test_design_window.py::test_required_areas_offscreen -vv`
- `pytest tests/test_moment_app.py -vv`
- `pytest -q` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_687048a13470832b9d83931b30f0ea91