### PR TITLE
Update shear scheme drawing style

### DIFF
--- a/vigapp/graphics/shear_scheme.py
+++ b/vigapp/graphics/shear_scheme.py
@@ -5,6 +5,7 @@ from matplotlib.patches import Rectangle
 
 
 def _dim_line(ax, x1, x2, y, label, offset=0.15):
+    """Draw a dimension line with a centered label."""
     ax.annotate(
         "",
         xy=(x1, y),
@@ -12,7 +13,14 @@ def _dim_line(ax, x1, x2, y, label, offset=0.15):
         arrowprops=dict(arrowstyle="<->", color="black", lw=1),
         annotation_clip=False,
     )
-    ax.text((x1 + x2) / 2, y - offset, label, ha="center", va="top", fontsize=9)
+    ax.text(
+        (x1 + x2) / 2,
+        y - offset,
+        label,
+        ha="center",
+        va="top",
+        fontsize=9,
+    )
 
 
 def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: str = "apoyada") -> None:
@@ -32,44 +40,81 @@ def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: s
         Either ``"apoyada"`` or ``"volado"``.
     """
     ax.clear()
+
     h = 0.4
     support_w = 0.2
     y0 = 0
+    margin = ln * 0.1
+    arrow_len = margin * 0.4
+    dim_y1 = y0 - margin * 0.2
+    dim_y2 = y0 - margin * 0.4
 
     # Beam rectangle
     if beam_type == "volado":
         ax.add_patch(Rectangle((0, y0), ln, h, edgecolor="black", facecolor="none"))
         ax.add_patch(Rectangle((-support_w, y0), support_w, h, facecolor="0.7"))
+
         x_vu = ln - d
         ax.annotate(
             "",
             xy=(x_vu, h),
-            xytext=(x_vu, h + 0.3),
+            xytext=(x_vu, h + arrow_len),
             arrowprops=dict(arrowstyle="-|>", color="red", lw=2),
         )
-        ax.text(x_vu, h + 0.32, "Vu", color="red", ha="center", va="bottom", fontsize=9)
-        ax.plot([0, ln], [h, 0], color="blue", lw=1)
-        _dim_line(ax, ln, x_vu, y0 - 0.1, "d")
-        _dim_line(ax, 0, ln, y0 - 0.25, f"ln = {ln:.2f} m")
-        ax.set_xlim(-support_w - 0.2, ln + 0.2)
+        ax.text(
+            x_vu,
+            h + arrow_len + 0.02,
+            "Vu",
+            color="red",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+
+        ax.plot([0, ln], [0, h], color="blue", lw=1)
+
+        _dim_line(ax, x_vu, ln, dim_y1, "d")
+        _dim_line(ax, 0, ln, dim_y2, f"ln = {ln:.2f} m")
+
+        ax.set_xlim(-support_w - margin, ln + margin)
     else:
         ax.add_patch(Rectangle((0, y0), ln, h, edgecolor="black", facecolor="none"))
+
         x_vu_left = d
         x_vu_right = ln - d
         for x_vu in (x_vu_left, x_vu_right):
             ax.annotate(
                 "",
                 xy=(x_vu, h),
-                xytext=(x_vu, h + 0.3),
+                xytext=(x_vu, h + arrow_len),
                 arrowprops=dict(arrowstyle="-|>", color="red", lw=2),
             )
-            ax.text(x_vu, h + 0.32, "Vu", color="red", ha="center", va="bottom", fontsize=9)
+            ax.text(
+                x_vu,
+                h + arrow_len + 0.02,
+                "Vu",
+                color="red",
+                ha="center",
+                va="bottom",
+                fontsize=9,
+            )
+
+        # Compression line
         ax.plot([0, ln], [h, 0], color="blue", lw=1)
-        _dim_line(ax, 0, d, y0 - 0.1, "d")
-        _dim_line(ax, ln/2, ln, y0 - 0.1, "ln/2")
-        _dim_line(ax, 0, ln, y0 - 0.25, f"ln = {ln:.2f} m")
-        ax.set_xlim(-0.2, ln + 0.2)
+
+        # Support marks
+        mark_h = h * 0.25
+        ax.plot([0, 0], [y0, y0 - mark_h], color="black", lw=1)
+        ax.plot([ln, ln], [y0, y0 - mark_h], color="black", lw=1)
+
+        # Dimension lines
+        _dim_line(ax, 0, d, dim_y1, "d")
+        _dim_line(ax, ln / 2, ln, dim_y1, "ln/2")
+        _dim_line(ax, 0, ln, dim_y2, f"ln = {ln:.2f} m")
+
+        ax.set_xlim(-margin, ln + margin)
 
     ax.axis("off")
-    ax.set_ylim(-0.5, h + 0.5)
+    ax.set_ylim(y0 - margin * 0.6, h + margin * 0.6)
+
 

--- a/vigapp/ui/menu_window.py
+++ b/vigapp/ui/menu_window.py
@@ -233,8 +233,8 @@ class MenuWindow(QMainWindow):
             btn_layout.addLayout(row)
 
         add_row(btn_flex, "DISE\u00d1O POR FLEXI\u00d3N")
-        add_row(btn_torsion, "DISE\u00d1O POR TORSI\u00d3N")
         add_row(btn_cort, "DISE\u00d1O POR CORTANTE")
+        add_row(btn_torsion, "DISE\u00d1O POR TORSI\u00d3N")
         add_row(btn_mem, "MEMORIA DE C\u00c1LCULO")
         add_row(btn_contact, "CONTACTO")
         btn_layout.addItem(


### PR DESCRIPTION
## Summary
- enhance shear_scheme diagram for technical look
- reorder menu so Diseño por Corte appears second

## Testing
- `pytest tests/test_shear_window.py::test_shear_diagram_offscreen -q`
- `pytest tests/test_design_window.py::test_required_areas_offscreen -q`
- `pytest tests/test_moment_app.py::test_correct_moments_dual1_dual2 -q`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6871c99ad498832b8c4ab54823c48677