### PR TITLE
Implement shear design calculations

### DIFF
--- a/tests/test_shear_design.py
+++ b/tests/test_shear_design.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from vigapp.models.shear_design import shear_design, min_spacing_sc, max_spacing_sr
+
+
+def test_shear_design_sample():
+    res = shear_design(
+        Vu=30,
+        Ln=6,
+        d=50,
+        b=30,
+        h=60,
+        fc=210,
+        phi_long=1.27,
+    )
+    assert res.ok
+    assert abs(res.S_sc - 12.55) < 0.1
+    assert abs(res.Lc - 4.0) < 1e-6
+    assert res.phi_Vc_Vs >= 30
+
+
+def test_min_spacing():
+    sc = min_spacing_sc(50, 1.27, 0.95)
+    sr = max_spacing_sr(50)
+    assert sc <= 15
+    assert sr <= 25

--- a/vigapp/models/shear_design.py
+++ b/vigapp/models/shear_design.py
@@ -1,0 +1,117 @@
+"""Simple shear design calculations based on README_SHEAR.md."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+
+
+# Available stirrup diameters and areas (cm^2)
+BAR_AREAS = {
+    '3/8"': 0.71,
+    '1/2"': 1.27,
+    '5/8"': 1.98,
+}
+
+# Diameters in centimeters for each option
+BAR_DIAM_CM = {
+    '3/8"': 0.95,
+    '1/2"': 1.27,
+    '5/8"': 1.59,
+}
+
+
+@dataclass
+class ShearDesignResult:
+    """Result summary for shear design."""
+
+    Vc: float
+    Vs: float
+    phi_Vc: float
+    phi_Vc_Vs: float
+    S_sc: float
+    S_sr: float
+    Lo: float
+    Lc: float
+    ok: bool
+
+
+def calc_vc(fc: float, b: float, d: float) -> float:
+    """Return concrete shear capacity ``Vc`` in tons."""
+    vc_kg = 0.53 * sqrt(fc) * b * d
+    return vc_kg / 1000.0
+
+
+def min_spacing_sc(d: float, phi_long: float, phi_stirr: float) -> float:
+    """Return minimum stirrup spacing for the confinement zone (cm)."""
+    opts = [max(d / 4.0, 15.0), 10.0 * phi_long, 24.0 * phi_stirr, 30.0]
+    return min(opts)
+
+
+def max_spacing_sr(d: float) -> float:
+    """Return maximum stirrup spacing for the remaining zone (cm)."""
+    return min(0.5 * d, 30.0)
+
+
+def shear_design(
+    Vu: float,
+    Ln: float,
+    d: float,
+    b: float,
+    h: float,
+    fc: float,
+    *,
+    fy: float = 4200.0,
+    phi: float = 0.85,
+    system: str = "dual2",
+    stirrup_diam: str = '3/8"',
+    phi_long: float = 1.0,
+    n_legs: int = 2,
+) -> ShearDesignResult:
+    """Compute stirrup spacing for a reinforced concrete beam."""
+
+    if stirrup_diam not in BAR_AREAS:
+        raise ValueError("Di\u00e1metro de estribo no v\u00e1lido")
+
+    Vc = calc_vc(fc, b, d)
+    phi_Vc = phi * Vc
+
+    Av = n_legs * BAR_AREAS[stirrup_diam]
+    phi_st = BAR_DIAM_CM[stirrup_diam]
+
+    # Required shear carried by steel (tons)
+    Vs_req = max(Vu / phi - Vc, 0.0)
+
+    if Vs_req > 0:
+        S_req = Av * fy * d / (Vs_req * 1000.0)
+    else:
+        S_req = float("inf")
+
+    sc_min = min_spacing_sc(d, phi_long, phi_st)
+    sr_max = max_spacing_sr(d)
+
+    S_sc = min(S_req, sc_min)
+    S_sr = min(S_req, sr_max)
+
+    Vs_prov = Av * fy * d / min(S_sc, S_sr) / 1000.0
+    phi_Vc_Vs = phi * (Vc + Vs_prov)
+    ok = Vu <= phi_Vc_Vs
+
+    if system.lower() == "dual1":
+        Lo = 2.0 * h / 100.0
+    else:
+        Lo = 2.0 * d / 100.0
+    Lc = max(Ln - 2.0 * Lo, 0.0)
+
+    return ShearDesignResult(
+        Vc=Vc,
+        Vs=Vs_prov,
+        phi_Vc=phi_Vc,
+        phi_Vc_Vs=phi_Vc_Vs,
+        S_sc=S_sc,
+        S_sr=S_sr,
+        Lo=Lo,
+        Lc=Lc,
+        ok=ok,
+    )
+


### PR DESCRIPTION
## Summary
- add `shear_design` module implementing formulas from README_SHEAR
- add tests covering shear design computations

## Testing
- `pytest tests/test_shear_design.py -q`
- `pytest tests/test_design_window.py::test_calc_as_req_sample -q`
- `pytest tests/test_design_window.py::test_required_areas_offscreen -q`
- `pytest tests/test_shear_window.py::test_shear_diagram_offscreen -q`


------
https://chatgpt.com/codex/tasks/task_e_6871d9e83538832bbfe08c041c58ee06