### PR TITLE
Allow shear design without flexion

### DIFF
--- a/tests/test_design_window.py
+++ b/tests/test_design_window.py
@@ -36,3 +36,5 @@ def test_required_areas_offscreen(monkeypatch):
     assert np.all(as_p >= win.as_min)
     assert np.all(as_p <= win.as_max)
 
+    app.quit()
+

--- a/tests/test_shear_window.py
+++ b/tests/test_shear_window.py
@@ -17,3 +17,11 @@ def test_shear_diagram_offscreen(monkeypatch):
     shear.ed_vu.setText("30")
     shear.ed_ln.setText("6")
     shear.draw_diagram()
+    assert shear.ed_d.isReadOnly()
+
+    shear2 = ShearDesignWindow(None, show_window=False)
+    shear2.ed_vu.setText("30")
+    shear2.ed_ln.setText("6")
+    shear2.draw_diagram()
+    assert not shear2.ed_d.isReadOnly()
+    app.quit()

--- a/vigapp/ui/menu_window.py
+++ b/vigapp/ui/menu_window.py
@@ -338,14 +338,12 @@ class MenuWindow(QMainWindow):
         generar_reporte_html(datos, resultados, tabla, imagenes, seccion, dev_as)
 
     def open_cortante(self):
-        if not hasattr(self, "design_page"):
-            QMessageBox.warning(self, "Advertencia", "Primero complete el diseño por flexión")
-            return
+        design_ref = getattr(self, "design_page", None)
         self.cortante_page = ShearDesignWindow(
-            self.design_page,
+            design_ref,
             show_window=False,
             menu_callback=self.show_menu,
-            back_callback=self.show_design,
+            back_callback=self.show_design if design_ref else self.show_menu,
         )
         self.stacked.addWidget(self.cortante_page)
         self.stacked.setCurrentWidget(self.cortante_page)

--- a/vigapp/ui/shear_window.py
+++ b/vigapp/ui/shear_window.py
@@ -21,7 +21,7 @@ from ..graphics.shear_scheme import draw_shear_scheme
 class ShearDesignWindow(QMainWindow):
     """UI to input Vu and plot a linear shear diagram."""
 
-    def __init__(self, design_win, parent=None, *, show_window=True,
+    def __init__(self, design_win=None, parent=None, *, show_window=True,
                  menu_callback=None, back_callback=None):
         super().__init__(parent)
         self.design_win = design_win
@@ -48,9 +48,13 @@ class ShearDesignWindow(QMainWindow):
         self.cb_type = QComboBox()
         self.cb_type.addItems(["Apoyada", "Volado"])
 
-        d_val = self.design_win.calc_effective_depth()
-        self.ed_d = QLineEdit(f"{d_val:.2f}")
-        self.ed_d.setReadOnly(True)
+        if self.design_win is not None:
+            d_val = self.design_win.calc_effective_depth()
+            self.ed_d = QLineEdit(f"{d_val:.2f}")
+            self.ed_d.setReadOnly(True)
+        else:
+            self.ed_d = QLineEdit("50.0")
+            self.ed_d.setReadOnly(False)
         self.ed_d.setAlignment(Qt.AlignRight)
 
         layout.addWidget(QLabel("Vu (T)"), 0, 0)


### PR DESCRIPTION
## Summary
- make ShearDesignWindow accept `None` design reference
- update menu to open shear design without requiring flexion
- adjust tests for PyQt windows

## Testing
- `pytest tests/test_design_window.py -q && pytest tests/test_moment_app.py -q && pytest tests/test_shear_design.py -q && pytest tests/test_shear_window.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ddc18a40832b99122e95aa0a15a4